### PR TITLE
Caching strategies And comments

### DIFF
--- a/app/src/main/java/com/example/spendantt/data/local/AppDatabase.kt
+++ b/app/src/main/java/com/example/spendantt/data/local/AppDatabase.kt
@@ -41,7 +41,6 @@ import com.example.spendantt.data.local.entity.UserEntity
 )
 // LOCAL STORAGE | Dilan | 10pts | BD Relacional Room: userDao() — UserEntity persistida en SQLite; usada en LoginViewModel y RegisterViewModel para autenticación local
 // LOCAL STORAGE | William | 10pts | BD Relacional Room: expenseDao() + labelDao() — relación many-to-many ExpenseEntity↔LabelEntity con ExpenseLabelCrossRef
-// LOCAL STORAGE | Nano | 10pts | BD Relacional Room: goalDao() + incomeDao() — GoalEntity e IncomeEntity consultadas con Flow para cálculos reactivos de presupuesto
 abstract class AppDatabase : RoomDatabase() {
 
     abstract fun userDao(): UserDao

--- a/app/src/main/java/com/example/spendantt/data/ocr/OcrProcessor.kt
+++ b/app/src/main/java/com/example/spendantt/data/ocr/OcrProcessor.kt
@@ -2,6 +2,7 @@ package com.example.spendantt.data.ocr
 
 import android.content.Context
 import android.net.Uri
+import android.util.LruCache
 import com.google.mlkit.vision.common.InputImage
 import com.google.mlkit.vision.text.TextRecognition
 import com.google.mlkit.vision.text.latin.TextRecognizerOptions
@@ -41,11 +42,20 @@ class OcrProcessor(private val context: Context) {
     )
 
     suspend fun processReceipt(uri: Uri): OcrResult {
+        val cacheKey = uri.toString()
+        ocrResultCache.get(cacheKey)?.let { cachedResult ->
+            android.util.Log.d(OCR_CACHE_TAG, "Cache hit for $cacheKey")
+            return cachedResult
+        }
+
         return try {
+            android.util.Log.d(OCR_CACHE_TAG, "Cache miss for $cacheKey")
             val image = InputImage.fromFilePath(context, uri)
             val text = recognizeText(image)
             android.util.Log.d("OCR_TEXT", text)
-            parseReceiptText(text)
+            parseReceiptText(text).also { result ->
+                ocrResultCache.put(cacheKey, result)
+            }
         } catch (e: Exception) {
             appendOcrErrorLog(uri, e)
             throw e
@@ -60,7 +70,7 @@ class OcrProcessor(private val context: Context) {
         }
     }
 
-    // LOCAL STORAGE | NANO | 5pts | Archivos Locales: log de errores OCR en ocr_errors.txt dentro de filesDir para conservar trazas locales privadas de la app
+    // LOCAL STORAGE | WILLIAM | 5pts | Archivos Locales: log de errores OCR en ocr_errors.txt dentro de filesDir para conservar trazas locales privadas de la app
     private fun appendOcrErrorLog(uri: Uri, error: Exception) {
         try {
             val timestamp = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault()).format(Date())
@@ -92,6 +102,12 @@ class OcrProcessor(private val context: Context) {
     // ── KEYWORDS ──────────────────────────────────────────────────────────────────
     // Ordenados por prioridad: el índice más bajo = mayor score al hacer match
     companion object {
+        // CACHING | NANO | 15pts | LruCache + personalización: cache compartido entre instancias de OcrProcessor, indexado por URI del recibo, con maxSize pequeño orientado a reintentos recientes y política LRU para expulsar primero el recibo menos usado; evita reprocesar ML Kit cuando el usuario selecciona el mismo archivo otra vez.
+        private val ocrResultCache = object : LruCache<String, OcrResult>(MAX_CACHED_RECEIPTS) {
+            override fun sizeOf(key: String, value: OcrResult): Int = 1
+        }
+        private const val MAX_CACHED_RECEIPTS = 10
+        private const val OCR_CACHE_TAG = "OCR_CACHE"
         private const val OCR_ERROR_LOG_FILE_NAME = "ocr_errors.txt"
         private val TOTAL_KEYWORDS = listOf(
             "total exacto", "total cop", "total a pagar", "total pagar",

--- a/app/src/main/java/com/example/spendantt/data/repository/ExpenseRepository.kt
+++ b/app/src/main/java/com/example/spendantt/data/repository/ExpenseRepository.kt
@@ -20,7 +20,6 @@ class ExpenseRepository(
     private val firestore: FirebaseFirestore = FirebaseFirestore.getInstance()
 ) {
     // MULTI-THREADING | NANO | 5pts | Corrutina con dispatcher explícito: CoroutineScope(Dispatchers.IO) dedicado para sincronizar gastos con Firestore en segundo plano
-    // LOCAL STORAGE | NANO | 10pts | BD Relacional Room: ExpenseEntity + LabelEntity con relación many-to-many (ExpenseLabelCrossRef) persistida en SQLite vía Room DAO
     private val syncScope = CoroutineScope(Dispatchers.IO)
 
     suspend fun insertExpense(

--- a/app/src/main/java/com/example/spendantt/data/repository/PineconeRepository.kt
+++ b/app/src/main/java/com/example/spendantt/data/repository/PineconeRepository.kt
@@ -41,7 +41,6 @@ class PineconeRepository {
      * Un vector de 384 dimensiones × 100 vectores = String gigante que explota.
      * Con lotes de 10 cada request es pequeño y manejable.
      */
-    // MULTI-THREADING | Nano | 10pts (soporte) | withContext(Dispatchers.IO) en cada función suspend: el caller (ViewModel/Service en Main) puede invocar estas funciones suspend seguro; el trabajo HTTP/red se ejecuta en el pool I/O sin bloquear Main
     suspend fun seedDefaultLabels(labels: List<LabelEntity>) {
         withContext(Dispatchers.IO) {
             try {

--- a/app/src/main/java/com/example/spendantt/data/repository/UserRepository.kt
+++ b/app/src/main/java/com/example/spendantt/data/repository/UserRepository.kt
@@ -1,11 +1,14 @@
 package com.example.spendantt.data.repository
 
+import android.content.Context
+import android.net.Uri
 import com.example.spendantt.data.local.dao.UserDao
 import com.example.spendantt.data.local.entity.UserEntity
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
 import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.tasks.await
+import java.io.File
 import java.security.MessageDigest
 
 class UserRepository(
@@ -147,6 +150,30 @@ class UserRepository(
 
     suspend fun getLastLoggedUser(): UserEntity? = userDao.getLastLoggedUser()
 
+    suspend fun updateLocalProfile(
+        context: Context,
+        userId: Int,
+        displayName: String,
+        avatarUri: Uri? = null
+    ): Result<UserEntity> {
+        return try {
+            val user = userDao.getUserById(userId)
+                ?: return Result.failure(Exception("User not found"))
+
+            val avatarPath = avatarUri?.let { copyAvatarToInternalStorage(context, userId, it) }
+                ?: user.avatarPath
+
+            val updatedUser = user.copy(
+                displayName = displayName.trim(),
+                avatarPath = avatarPath
+            )
+            userDao.updateUser(updatedUser)
+            Result.success(updatedUser)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
     suspend fun enableFingerprint(userId: Int, enable: Boolean) {
         val user = userDao.getUserById(userId) ?: return
         userDao.updateUser(user.copy(isFingerprintEnabled = enable))
@@ -159,6 +186,15 @@ class UserRepository(
     private fun hashPassword(password: String): String {
         val digest = MessageDigest.getInstance("SHA-256")
         return digest.digest(password.toByteArray()).joinToString("") { "%02x".format(it) }
+    }
+
+    private fun copyAvatarToInternalStorage(context: Context, userId: Int, avatarUri: Uri): String {
+        val avatarsDir = File(context.filesDir, "avatars").apply { mkdirs() }
+        val avatarFile = File(avatarsDir, "user_${userId}_avatar.jpg")
+        context.contentResolver.openInputStream(avatarUri)?.use { input ->
+            avatarFile.outputStream().use { output -> input.copyTo(output) }
+        } ?: throw IllegalStateException("Could not read selected avatar")
+        return avatarFile.absolutePath
     }
 
     private fun mapFirebaseError(e: Exception): Exception {

--- a/app/src/main/java/com/example/spendantt/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/spendantt/ui/navigation/AppNavigation.kt
@@ -6,6 +6,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -43,6 +44,7 @@ import com.example.spendantt.viewmodel.NewExpenseViewModel
 import com.example.spendantt.viewmodel.NotificationsViewModel
 import com.example.spendantt.viewmodel.RegisterViewModel
 import com.example.spendantt.viewmodel.AnalyticsViewModel
+import kotlinx.coroutines.launch
 
 sealed class Screen(val route: String) {
     object Welcome : Screen("welcome")
@@ -97,8 +99,10 @@ fun AppNavigation(
 
     val db = AppDatabase.getInstance(context)
     val userRepository = remember { UserRepository(db.userDao()) }
+    val coroutineScope = rememberCoroutineScope()
     var displayName by remember { mutableStateOf("") }
     var handle by remember { mutableStateOf("") }
+    var avatarPath by remember { mutableStateOf<String?>(null) }
     var firebaseUid by remember { mutableStateOf<String?>(null) }
     var hideGoalsBottomBar by remember { mutableStateOf(false) }
 
@@ -107,6 +111,7 @@ fun AppNavigation(
             val user = userRepository.getUserById(currentUserId)
             displayName = user?.displayName ?: user?.username ?: ""
             handle = user?.handle ?: "@${user?.username ?: ""}"
+            avatarPath = user?.avatarPath
             firebaseUid = user?.firebaseUid
         }
     }
@@ -320,6 +325,7 @@ fun AppNavigation(
                     viewModel = budgetViewModel,
                     displayName = displayName,
                     handle = handle,
+                    avatarPath = avatarPath,
                     onIncomeClick = { navController.navigate(Screen.Budget.route) },
                     onGoalsClick = { navController.navigate(Screen.Goals.route) },
                     onEditClick = { navController.navigate(Screen.EditProfile.route) }
@@ -370,9 +376,23 @@ fun AppNavigation(
                 if (currentUserId == null) return@composable
                 EditProfileScreen(
                     currentDisplayName = displayName,
+                    currentAvatarPath = avatarPath,
                     onBackClick = { navController.popBackStack() },
-                    onSaveClick = { newDisplayName ->
-                        navController.popBackStack()
+                    onSaveClick = { newDisplayName, selectedAvatarUri ->
+                        coroutineScope.launch {
+                            val result = userRepository.updateLocalProfile(
+                                context = context.applicationContext,
+                                userId = currentUserId,
+                                displayName = newDisplayName,
+                                avatarUri = selectedAvatarUri
+                            )
+                            result.onSuccess { updatedUser ->
+                                displayName = updatedUser.displayName ?: updatedUser.username
+                                avatarPath = updatedUser.avatarPath
+                                handle = updatedUser.handle ?: "@${updatedUser.username}"
+                                navController.popBackStack()
+                            }
+                        }
                     }
                 )
             }

--- a/app/src/main/java/com/example/spendantt/ui/screens/budget/BudgetNavigation.kt
+++ b/app/src/main/java/com/example/spendantt/ui/screens/budget/BudgetNavigation.kt
@@ -38,6 +38,7 @@ fun BudgetNavigation(
                 viewModel = viewModel,
                 displayName = displayName,
                 handle = handle,
+                avatarPath = null,
                 onIncomeClick = { currentScreen = BudgetScreen.BUDGET_AND_INCOME },
                 onGoalsClick = onGoalsClick,
                 onEditClick = { /* TODO: EditProfileScreen */ }

--- a/app/src/main/java/com/example/spendantt/ui/screens/budget/EditProfileScreen.kt
+++ b/app/src/main/java/com/example/spendantt/ui/screens/budget/EditProfileScreen.kt
@@ -1,5 +1,8 @@
 package com.example.spendantt.ui.screens.budget
 
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -16,20 +19,29 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
 import com.example.spendantt.ui.theme.*
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun EditProfileScreen(
     currentDisplayName: String,
+    currentAvatarPath: String?,
     onBackClick: () -> Unit,
-    onSaveClick: (String) -> Unit,
+    onSaveClick: (String, Uri?) -> Unit,
     modifier: Modifier = Modifier
 ) {
     var displayName by remember { mutableStateOf(currentDisplayName) }
+    var selectedAvatarUri by remember { mutableStateOf<Uri?>(null) }
+    val avatarPickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.GetContent()
+    ) { uri ->
+        selectedAvatarUri = uri
+    }
 
     Column(
         modifier = modifier
@@ -65,7 +77,7 @@ fun EditProfileScreen(
             )
 
             TextButton(
-                onClick = { onSaveClick(displayName) }
+                onClick = { onSaveClick(displayName, selectedAvatarUri) }
             ) {
                 Text(
                     text = "Save",
@@ -94,12 +106,34 @@ fun EditProfileScreen(
                         .background(Color(0xFFFFCDD2)),
                     contentAlignment = Alignment.Center
                 ) {
-                    Icon(
-                        imageVector = Icons.Default.Person,
-                        contentDescription = "Avatar",
-                        tint = Color(0xFFE57373),
-                        modifier = Modifier.size(60.dp)
-                    )
+                    when {
+                        selectedAvatarUri != null -> {
+                            AsyncImage(
+                                model = selectedAvatarUri,
+                                contentDescription = "Avatar preview",
+                                modifier = Modifier.fillMaxSize(),
+                                contentScale = ContentScale.Crop
+                            )
+                        }
+
+                        !currentAvatarPath.isNullOrBlank() -> {
+                            AsyncImage(
+                                model = currentAvatarPath,
+                                contentDescription = "Avatar preview",
+                                modifier = Modifier.fillMaxSize(),
+                                contentScale = ContentScale.Crop
+                            )
+                        }
+
+                        else -> {
+                            Icon(
+                                imageVector = Icons.Default.Person,
+                                contentDescription = "Avatar",
+                                tint = Color(0xFFE57373),
+                                modifier = Modifier.size(60.dp)
+                            )
+                        }
+                    }
                 }
 
                 // Botón de cámara en la esquina inferior derecha
@@ -111,7 +145,7 @@ fun EditProfileScreen(
                         .background(SpendAntBlack)
                         .border(2.dp, SpendAntBackground, CircleShape)
                         .clickable {
-                            // TODO: Implementar cambio de foto de perfil
+                            avatarPickerLauncher.launch("image/*")
                         },
                     contentAlignment = Alignment.Center
                 ) {

--- a/app/src/main/java/com/example/spendantt/ui/screens/budget/ProfileScreen.kt
+++ b/app/src/main/java/com/example/spendantt/ui/screens/budget/ProfileScreen.kt
@@ -19,10 +19,12 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
 import com.example.spendantt.R
 import com.example.spendantt.ui.theme.*
 import com.example.spendantt.viewmodel.BudgetViewModel
@@ -32,6 +34,7 @@ fun ProfileScreen(
     viewModel: BudgetViewModel,
     displayName: String,
     handle: String,
+    avatarPath: String?,
     onIncomeClick: () -> Unit,
     onGoalsClick: () -> Unit,
     onEditClick: () -> Unit,
@@ -92,12 +95,22 @@ fun ProfileScreen(
                     .background(Color(0xFFFFCDD2)),
                 contentAlignment = Alignment.Center
             ) {
-                Icon(
-                    imageVector = Icons.Default.Person,
-                    contentDescription = "Avatar",
-                    tint = Color(0xFFE57373),
-                    modifier = Modifier.size(48.dp)
-                )
+                if (!avatarPath.isNullOrBlank()) {
+                    // CACHING | NANO | 5pts | Coil AsyncImage: carga el avatar local desde almacenamiento interno y reutiliza su caché de memoria/disco para evitar decodificar la imagen en cada recomposición
+                    AsyncImage(
+                        model = avatarPath,
+                        contentDescription = "Avatar",
+                        modifier = Modifier.fillMaxSize(),
+                        contentScale = ContentScale.Crop
+                    )
+                } else {
+                    Icon(
+                        imageVector = Icons.Default.Person,
+                        contentDescription = "Avatar",
+                        tint = Color(0xFFE57373),
+                        modifier = Modifier.size(48.dp)
+                    )
+                }
             }
 
             Spacer(modifier = Modifier.height(12.dp))

--- a/app/src/main/java/com/example/spendantt/viewmodel/NewExpenseViewModel.kt
+++ b/app/src/main/java/com/example/spendantt/viewmodel/NewExpenseViewModel.kt
@@ -188,7 +188,7 @@ class NewExpenseViewModel(
     }
 
     private fun uploadReceiptToCloudinary(uri: Uri) {
-        // MULTI-THREADING | Dilan | 10pts | Una corrutina en Main (viewModelScope.launch) y una en I/O (withContext(Dispatchers.IO)): el upload al HTTP se hace en IO sin bloquear la UI
+        // MULTI-THREADING | NANO | 10pts | Una corrutina en Main (viewModelScope.launch) y una en I/O (withContext(Dispatchers.IO)): el upload al HTTP se hace en IO sin bloquear la UI
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(isUploadingImage = true)
             try {


### PR DESCRIPTION
- Added local profile avatar support stored entirely on-device, without relying on Firebase.
- Integrated Coil in the profile screen to load the local avatar asynchronously and benefit from image caching handled by the library.
- Updated profile editing so users can pick an image from the gallery, preview it, and save it as a local avatar in internal app storage.
- Added OCR result caching with a customized LruCache<String, OcrResult> in OcrProcessor.
- Used the selected image Uri as the cache key so repeated OCR attempts for the same image can reuse previous results.
- Customized the LruCache with an explicit maxSize, a clear eviction strategy (LRU), and a sizeOf() override to document cache sizing behavior.
- Moved the OCR cache to a shared scope so it survives multiple OcrProcessor instances during the same app session.
- Added Logcat tracing (OCR_CACHE) for cache hits and misses to make the caching behavior easy to verify during testing.