### PR TITLE
Fix: Voice Expenses

### DIFF
--- a/app/src/main/java/com/example/spendantt/ui/screens/expense/NewExpenseScreen.kt
+++ b/app/src/main/java/com/example/spendantt/ui/screens/expense/NewExpenseScreen.kt
@@ -29,11 +29,15 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
+import kotlin.math.PI
+import kotlin.math.abs
+import kotlin.math.sin
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
@@ -1415,8 +1419,8 @@ internal fun VoiceInputScreen(
         else voiceViewModel.stopListening()
     }
 
-    val infiniteTransition = rememberInfiniteTransition(label = "mic_pulse")
-    val pulseAlpha by infiniteTransition.animateFloat(
+    val micTransition = rememberInfiniteTransition(label = "mic_pulse")
+    val pulseAlpha by micTransition.animateFloat(
         initialValue = 1f,
         targetValue  = 0.55f,
         animationSpec = infiniteRepeatable(
@@ -1572,7 +1576,7 @@ internal fun VoiceInputScreen(
                                         "Amount"   to buildVoiceAmountPreview(result, currencyState.activeCurrency),
                                         "Location" to (result.locationName?.replaceFirstChar { it.uppercase() } ?: "-"),
                                         "Date"     to (result.date ?: "-")
-                                    ).forEach { (label, value) ->
+                                    ).filter { (_, value) -> value != "-" }.forEach { (label, value) ->
                                         Row(
                                             modifier = Modifier.fillMaxWidth(),
                                             horizontalArrangement = Arrangement.spacedBy(12.dp)
@@ -1621,6 +1625,22 @@ internal fun VoiceInputScreen(
                 }
 
                 // ── Mic button ────────────────────────────────────────────
+                // Espacio fijo: el waveform se dibuja aquí cuando está escuchando.
+                // Altura constante para que el botón no se mueva.
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(52.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    if (uiState.isListening) {
+                        VoiceWaveform(
+                            rmsDb    = uiState.rmsDb,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
+                }
+
                 Box(
                     modifier = Modifier
                         .size(80.dp)
@@ -1655,6 +1675,45 @@ internal fun VoiceInputScreen(
                         fontSize   = 13.sp
                     )
                 }
+            }
+        }
+    }
+}
+
+@Composable
+private fun VoiceWaveform(rmsDb: Float, modifier: Modifier = Modifier) {
+    val amplitude = (rmsDb / 10f).coerceIn(0f, 1f)
+    val barCount = 20
+
+    val infiniteTransition = rememberInfiniteTransition(label = "waveform")
+    val animProgress by infiniteTransition.animateFloat(
+        initialValue = 0f,
+        targetValue  = (2.0 * PI).toFloat(),
+        animationSpec = infiniteRepeatable(
+            animation  = tween(900, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart
+        ),
+        label = "wave"
+    )
+
+    Box(modifier = modifier, contentAlignment = Alignment.Center) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(3.dp),
+            verticalAlignment     = Alignment.CenterVertically
+        ) {
+            repeat(barCount) { i ->
+                val phase      = i * (2.0 * PI / barCount).toFloat()
+                val sinVal     = sin((animProgress + phase).toDouble()).toFloat()
+                val normalized = (sinVal + 1f) / 2f
+                val bellWeight = 1f - abs(i - barCount / 2f) / (barCount / 2f) * 0.35f
+                val barHeight  = (4f + normalized * 36f * amplitude * bellWeight).dp
+                Box(
+                    modifier = Modifier
+                        .width(4.dp)
+                        .height(barHeight)
+                        .clip(RoundedCornerShape(2.dp))
+                        .background(SpendAntGreen)
+                )
             }
         }
     }

--- a/app/src/main/java/com/example/spendantt/viewmodel/VoiceInputViewModel.kt
+++ b/app/src/main/java/com/example/spendantt/viewmodel/VoiceInputViewModel.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.launch
 //   error 4/net  → show message, let user retry manually
 
 private const val TAG = "VoiceInputVM"
+private const val ERROR_SERVER_DISCONNECTED     = 11
 private const val ERROR_LANGUAGE_NOT_SUPPORTED  = 12
 private const val ERROR_LANGUAGE_UNAVAILABLE    = 13
 
@@ -40,7 +41,8 @@ data class VoiceInputUiState(
     val parsedResult: VoiceParseResult = VoiceParseResult(),
     val isParsing: Boolean            = false,
     val hasParsedResult: Boolean      = false,
-    val error: String?                = null
+    val error: String?                = null,
+    val rmsDb: Float                  = 0f
 )
 
 class VoiceInputViewModel(private val appContext: Context) {
@@ -121,13 +123,15 @@ class VoiceInputViewModel(private val appContext: Context) {
             _uiState.value = _uiState.value.copy(isListening = true, error = null)
         }
         override fun onBeginningOfSpeech() { Log.d(TAG, "onBeginningOfSpeech") }
-        override fun onRmsChanged(rmsdB: Float) {}
+        override fun onRmsChanged(rmsdB: Float) {
+            _uiState.value = _uiState.value.copy(rmsDb = rmsdB.coerceIn(-2f, 10f))
+        }
         override fun onBufferReceived(buf: ByteArray?) {}
         override fun onPartialResults(p: Bundle?) {}
         override fun onEvent(type: Int, p: Bundle?) {}
         override fun onEndOfSpeech() {
             Log.d(TAG, "onEndOfSpeech")
-            _uiState.value = _uiState.value.copy(isListening = false)
+            _uiState.value = _uiState.value.copy(isListening = false, rmsDb = 0f)
         }
 
         override fun onResults(results: Bundle) {
@@ -145,6 +149,15 @@ class VoiceInputViewModel(private val appContext: Context) {
                     Log.d(TAG, "Offline language unavailable (error=$error), retrying online")
                     _uiState.value = _uiState.value.copy(isListening = false, error = null)
                     startListeningInternal(preferOffline = false)
+                }
+                // Server disconnected mid-session → retry silently
+                error == ERROR_SERVER_DISCONNECTED -> {
+                    Log.d(TAG, "Server disconnected (error=11), retrying")
+                    _uiState.value = _uiState.value.copy(isListening = false, error = null, rmsDb = 0f)
+                    scope.launch {
+                        delay(500)
+                        startListeningInternal(preferOffline)
+                    }
                 }
                 // Recognizer busy or client error (previous session not released) → wait then retry
                 error == SpeechRecognizer.ERROR_RECOGNIZER_BUSY ||
@@ -186,7 +199,7 @@ class VoiceInputViewModel(private val appContext: Context) {
     fun cleanup() {
         recognizer?.destroy()
         recognizer = null
-        _uiState.value = _uiState.value.copy(isListening = false, isParsing = false)
+        _uiState.value = _uiState.value.copy(isListening = false, isParsing = false, rmsDb = 0f)
     }
 
     fun cancel() {


### PR DESCRIPTION
Bug fix — Error 11 silent retry (VoiceInputViewModel)

ERROR_SERVER_DISCONNECTED (code 11) now auto-retries after 500 ms
instead of showing an error to the user. Android disconnects the speech
server intermittently and this should be transparent.
Feature — Voice waveform animation (NewExpenseScreen)

Added VoiceWaveform composable: 20 animated green bars driven by the
microphone's real-time RMS level (onRmsChanged).
Bars only animate when the user is actually speaking (RMS > 0). When
silent, bars stay flat.
The waveform sits in a fixed-height 52dp container above the mic button
so the button never shifts position when the waveform appears or
disappears.
Mic button retains its pulse animation (alpha 1.0 → 0.55) while
listening.
UI — Parsed result card

Fields that were not detected (value "-") are no longer shown. The card
only displays what the parser actually captured (product, amount,
location, date).