### PR TITLE
Feature and Microoptimizations

### DIFF
--- a/app/src/main/java/com/example/spendantt/data/local/AppDatabase.kt
+++ b/app/src/main/java/com/example/spendantt/data/local/AppDatabase.kt
@@ -11,6 +11,7 @@ import com.example.spendantt.data.local.dao.ExchangeRateDao
 import com.example.spendantt.data.local.dao.GoalDao
 import com.example.spendantt.data.local.dao.IncomeDao
 import com.example.spendantt.data.local.dao.LabelDao
+import com.example.spendantt.data.local.dao.ReportCacheDao
 import com.example.spendantt.data.local.dao.UserDao
 import com.example.spendantt.data.local.entity.ExpenseEntity
 import com.example.spendantt.data.local.entity.ExpenseLabelCrossRef
@@ -18,6 +19,7 @@ import com.example.spendantt.data.local.entity.ExchangeRateEntity
 import com.example.spendantt.data.local.entity.GoalEntity
 import com.example.spendantt.data.local.entity.IncomeEntity
 import com.example.spendantt.data.local.entity.LabelEntity
+import com.example.spendantt.data.local.entity.ReportCacheEntity
 import com.example.spendantt.data.local.entity.UserEntity
 
 /**
@@ -37,9 +39,10 @@ import com.example.spendantt.data.local.entity.UserEntity
         ExpenseLabelCrossRef::class,
         IncomeEntity::class,
         GoalEntity::class,
-        ExchangeRateEntity::class
+        ExchangeRateEntity::class,
+        ReportCacheEntity::class
     ],
-    version = 5,
+    version = 6,
     exportSchema = false
 )
 // LOCAL STORAGE | Dilan | 10pts | BD Relacional Room: userDao() — UserEntity persistida en SQLite; usada en LoginViewModel y RegisterViewModel para autenticación local
@@ -52,6 +55,7 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun incomeDao(): IncomeDao
     abstract fun goalDao(): GoalDao
     abstract fun exchangeRateDao(): ExchangeRateDao
+    abstract fun reportCacheDao(): ReportCacheDao
 
     companion object {
         private const val DATABASE_NAME = "spendant_db"
@@ -66,7 +70,7 @@ abstract class AppDatabase : RoomDatabase() {
                     AppDatabase::class.java,
                     DATABASE_NAME
                 )
-                    .addMigrations(MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5)
+                    .addMigrations(MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6)
                     .build()
                 INSTANCE = instance
                 instance
@@ -84,6 +88,20 @@ abstract class AppDatabase : RoomDatabase() {
         val MIGRATION_3_4 = object : Migration(3, 4) {
             override fun migrate(database: SupportSQLiteDatabase) {
                 database.execSQL("ALTER TABLE labels ADD COLUMN category TEXT")
+            }
+        }
+
+        val MIGRATION_5_6 = object : Migration(5, 6) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    "CREATE TABLE IF NOT EXISTS report_cache (" +
+                        "cacheKey TEXT NOT NULL PRIMARY KEY, " +
+                        "userId INTEGER NOT NULL, " +
+                        "startEpochDay INTEGER NOT NULL, " +
+                        "endEpochDay INTEGER NOT NULL, " +
+                        "reportJson TEXT NOT NULL, " +
+                        "generatedAt INTEGER NOT NULL)"
+                )
             }
         }
 

--- a/app/src/main/java/com/example/spendantt/data/local/dao/ReportCacheDao.kt
+++ b/app/src/main/java/com/example/spendantt/data/local/dao/ReportCacheDao.kt
@@ -1,0 +1,26 @@
+package com.example.spendantt.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.example.spendantt.data.local.entity.ReportCacheEntity
+
+@Dao
+interface ReportCacheDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entity: ReportCacheEntity)
+
+    @Query("SELECT * FROM report_cache WHERE cacheKey = :key LIMIT 1")
+    suspend fun getByKey(key: String): ReportCacheEntity?
+
+    @Query("DELETE FROM report_cache WHERE cacheKey = :key")
+    suspend fun delete(key: String)
+
+    @Query("SELECT * FROM report_cache WHERE userId = :userId AND generatedAt >= :since ORDER BY generatedAt DESC")
+    suspend fun getRecentForUser(userId: Int, since: Long): List<ReportCacheEntity>
+
+    @Query("DELETE FROM report_cache WHERE generatedAt < :before")
+    suspend fun deleteOlderThan(before: Long)
+}

--- a/app/src/main/java/com/example/spendantt/data/local/entity/ReportCacheEntity.kt
+++ b/app/src/main/java/com/example/spendantt/data/local/entity/ReportCacheEntity.kt
@@ -1,0 +1,15 @@
+package com.example.spendantt.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "report_cache")
+data class ReportCacheEntity(
+    @PrimaryKey
+    val cacheKey: String,         // "{userId}_{startEpochDay}_{endEpochDay}"
+    val userId: Int,
+    val startEpochDay: Long,
+    val endEpochDay: Long,
+    val reportJson: String,
+    val generatedAt: Long,        // Unix millis
+)

--- a/app/src/main/java/com/example/spendantt/data/report/FinancialReport.kt
+++ b/app/src/main/java/com/example/spendantt/data/report/FinancialReport.kt
@@ -1,0 +1,42 @@
+package com.example.spendantt.data.report
+
+import java.time.LocalDate
+
+/**
+ * Snapshot of a spending report for a given user and date range.
+ * All monetary amounts are stored in COP (the canonical currency of the app).
+ * Display conversion to the active currency happens at render time.
+ */
+data class FinancialReport(
+    val startDate: LocalDate,
+    val endDate: LocalDate,
+    val periodLabel: String,                 // "May 3 - May 22, 2026"
+    val generatedAt: Long,                   // unix millis
+    val displayCurrency: String,             // currency used to format the displayed strings
+    val displayRate: Double,                 // copAmount * displayRate -> displayAmount
+    val totalSpentCop: Double,
+    val dailySpends: List<DailySpend>,
+    val topExpenses: List<TopExpense>,
+    val topCategories: List<CategoryTotal>,
+    val reportsGeneratedCount: Int,
+    val mostActiveWeekday: Int?,             // 1=Mon..7=Sun
+    val bqInsights: List<String>,
+)
+
+data class DailySpend(
+    val date: LocalDate,
+    val amountCop: Double,
+)
+
+data class TopExpense(
+    val name: String,
+    val amountCop: Double,
+    val category: String,
+    val date: LocalDate,
+)
+
+data class CategoryTotal(
+    val label: String,
+    val amountCop: Double,
+    val count: Int,
+)

--- a/app/src/main/java/com/example/spendantt/data/report/FinancialReportJson.kt
+++ b/app/src/main/java/com/example/spendantt/data/report/FinancialReportJson.kt
@@ -1,0 +1,119 @@
+package com.example.spendantt.data.report
+
+import org.json.JSONArray
+import org.json.JSONObject
+import java.time.LocalDate
+
+object FinancialReportJson {
+
+    fun encode(report: FinancialReport): String {
+        val obj = JSONObject().apply {
+            put("startDate", report.startDate.toString())
+            put("endDate", report.endDate.toString())
+            put("periodLabel", report.periodLabel)
+            put("generatedAt", report.generatedAt)
+            put("displayCurrency", report.displayCurrency)
+            put("displayRate", report.displayRate)
+            put("totalSpentCop", report.totalSpentCop)
+            put("reportsGeneratedCount", report.reportsGeneratedCount)
+            put("mostActiveWeekday", report.mostActiveWeekday ?: JSONObject.NULL)
+
+            put("dailySpends", JSONArray().apply {
+                report.dailySpends.forEach { ds ->
+                    put(JSONObject().apply {
+                        put("date", ds.date.toString())
+                        put("amountCop", ds.amountCop)
+                    })
+                }
+            })
+
+            put("topExpenses", JSONArray().apply {
+                report.topExpenses.forEach { te ->
+                    put(JSONObject().apply {
+                        put("name", te.name)
+                        put("amountCop", te.amountCop)
+                        put("category", te.category)
+                        put("date", te.date.toString())
+                    })
+                }
+            })
+
+            put("topCategories", JSONArray().apply {
+                report.topCategories.forEach { ct ->
+                    put(JSONObject().apply {
+                        put("label", ct.label)
+                        put("amountCop", ct.amountCop)
+                        put("count", ct.count)
+                    })
+                }
+            })
+
+            put("bqInsights", JSONArray(report.bqInsights))
+        }
+        return obj.toString()
+    }
+
+    fun decode(json: String): FinancialReport {
+        val obj = JSONObject(json)
+        val dailySpends = mutableListOf<DailySpend>()
+        val dailyArr = obj.optJSONArray("dailySpends") ?: JSONArray()
+        for (i in 0 until dailyArr.length()) {
+            val item = dailyArr.getJSONObject(i)
+            dailySpends.add(
+                DailySpend(
+                    date = LocalDate.parse(item.getString("date")),
+                    amountCop = item.getDouble("amountCop"),
+                )
+            )
+        }
+
+        val topExpenses = mutableListOf<TopExpense>()
+        val expensesArr = obj.optJSONArray("topExpenses") ?: JSONArray()
+        for (i in 0 until expensesArr.length()) {
+            val item = expensesArr.getJSONObject(i)
+            topExpenses.add(
+                TopExpense(
+                    name = item.getString("name"),
+                    amountCop = item.getDouble("amountCop"),
+                    category = item.getString("category"),
+                    date = LocalDate.parse(item.getString("date")),
+                )
+            )
+        }
+
+        val topCategories = mutableListOf<CategoryTotal>()
+        val catsArr = obj.optJSONArray("topCategories") ?: JSONArray()
+        for (i in 0 until catsArr.length()) {
+            val item = catsArr.getJSONObject(i)
+            topCategories.add(
+                CategoryTotal(
+                    label = item.getString("label"),
+                    amountCop = item.getDouble("amountCop"),
+                    count = item.getInt("count"),
+                )
+            )
+        }
+
+        val insights = mutableListOf<String>()
+        val insightsArr = obj.optJSONArray("bqInsights") ?: JSONArray()
+        for (i in 0 until insightsArr.length()) insights.add(insightsArr.getString(i))
+
+        val mostActiveWeekday = if (obj.isNull("mostActiveWeekday")) null else obj.getInt("mostActiveWeekday")
+
+        return FinancialReport(
+            startDate = LocalDate.parse(obj.getString("startDate")),
+            endDate = LocalDate.parse(obj.getString("endDate")),
+            periodLabel = obj.getString("periodLabel"),
+            generatedAt = obj.getLong("generatedAt"),
+            displayCurrency = obj.getString("displayCurrency"),
+            displayRate = obj.getDouble("displayRate"),
+            totalSpentCop = obj.getDouble("totalSpentCop"),
+            dailySpends = dailySpends,
+            topExpenses = topExpenses,
+            topCategories = topCategories,
+            reportsGeneratedCount = obj.getInt("reportsGeneratedCount"),
+            mostActiveWeekday = mostActiveWeekday,
+            bqInsights = insights,
+        )
+    }
+}

--- a/app/src/main/java/com/example/spendantt/data/report/ReportAggregator.kt
+++ b/app/src/main/java/com/example/spendantt/data/report/ReportAggregator.kt
@@ -1,0 +1,255 @@
+package com.example.spendantt.data.report
+
+import com.example.spendantt.data.local.entity.ExpenseWithLabels
+import java.text.DecimalFormat
+import java.text.DecimalFormatSymbols
+import java.time.DayOfWeek
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Calendar
+import java.util.Locale
+import kotlin.math.max
+import kotlin.math.roundToInt
+
+/**
+ * Builds a [FinancialReport] from raw expenses. Pure aggregation logic; no I/O.
+ *
+ * Inputs are taken in COP. The active currency is used only to format the
+ * BQ insight strings so they read naturally to the user.
+ */
+object ReportAggregator {
+
+    private const val SMALL_RECURRING_THRESHOLD_COP = 50_000.0
+    private const val MICRO_PURCHASE_THRESHOLD_COP = 5_000.0
+
+    fun build(
+        allExpensesAllTime: List<ExpenseWithLabels>,
+        startDate: LocalDate,
+        endDate: LocalDate,
+        displayCurrency: String,
+        displayRate: Double,
+        reportsGeneratedCount: Int,
+        zoneId: ZoneId = ZoneId.systemDefault(),
+        now: Instant = Instant.now(),
+    ): FinancialReport {
+
+        val periodExpenses = allExpensesAllTime.filter {
+            val d = Instant.ofEpochMilli(it.expense.date).atZone(zoneId).toLocalDate()
+            !d.isBefore(startDate) && !d.isAfter(endDate)
+        }
+
+        val totalSpentCop = periodExpenses.sumOf { it.expense.amount }
+
+        // Fill every day in the range so the histogram has no gaps.
+        val dailyMap = linkedMapOf<LocalDate, Double>()
+        var cursor = startDate
+        while (!cursor.isAfter(endDate)) {
+            dailyMap[cursor] = 0.0
+            cursor = cursor.plusDays(1)
+        }
+        periodExpenses.forEach { ewl ->
+            val d = Instant.ofEpochMilli(ewl.expense.date).atZone(zoneId).toLocalDate()
+            dailyMap[d] = (dailyMap[d] ?: 0.0) + ewl.expense.amount
+        }
+        val dailySpends = dailyMap.map { (date, amount) -> DailySpend(date, amount) }
+
+        val topExpenses = periodExpenses
+            .sortedByDescending { it.expense.amount }
+            .take(5)
+            .map { ewl ->
+                val d = Instant.ofEpochMilli(ewl.expense.date).atZone(zoneId).toLocalDate()
+                TopExpense(
+                    name = ewl.expense.name.ifBlank { "Unnamed expense" },
+                    amountCop = ewl.expense.amount,
+                    category = ewl.labels.firstOrNull()?.name ?: "Other",
+                    date = d,
+                )
+            }
+
+        val byCategory = linkedMapOf<String, Pair<Double, Int>>()
+        periodExpenses.forEach { ewl ->
+            val cat = ewl.labels.firstOrNull()?.name ?: "Other"
+            val current = byCategory[cat] ?: (0.0 to 0)
+            byCategory[cat] = (current.first + ewl.expense.amount) to (current.second + 1)
+        }
+        val topCategories = byCategory.entries
+            .sortedByDescending { it.value.first }
+            .take(5)
+            .map { (label, agg) -> CategoryTotal(label, agg.first, agg.second) }
+
+        val weekdayCounts = IntArray(7)
+        periodExpenses.forEach { ewl ->
+            val d = Instant.ofEpochMilli(ewl.expense.date).atZone(zoneId).toLocalDate()
+            weekdayCounts[d.dayOfWeek.value - 1] += 1
+        }
+        val mostActiveWeekday = weekdayCounts.indices
+            .maxByOrNull { weekdayCounts[it] }
+            ?.let { if (weekdayCounts[it] > 0) it + 1 else null }
+
+        val bqInsights = buildBqInsights(
+            allExpensesAllTime = allExpensesAllTime,
+            periodExpenses = periodExpenses,
+            startDate = startDate,
+            endDate = endDate,
+            displayCurrency = displayCurrency,
+            displayRate = displayRate,
+            reportsGeneratedCount = reportsGeneratedCount,
+            zoneId = zoneId,
+            now = now,
+        )
+
+        return FinancialReport(
+            startDate = startDate,
+            endDate = endDate,
+            periodLabel = formatPeriodLabel(startDate, endDate),
+            generatedAt = now.toEpochMilli(),
+            displayCurrency = displayCurrency,
+            displayRate = displayRate,
+            totalSpentCop = totalSpentCop,
+            dailySpends = dailySpends,
+            topExpenses = topExpenses,
+            topCategories = topCategories,
+            reportsGeneratedCount = reportsGeneratedCount,
+            mostActiveWeekday = mostActiveWeekday,
+            bqInsights = bqInsights,
+        )
+    }
+
+    private fun buildBqInsights(
+        allExpensesAllTime: List<ExpenseWithLabels>,
+        periodExpenses: List<ExpenseWithLabels>,
+        startDate: LocalDate,
+        endDate: LocalDate,
+        displayCurrency: String,
+        displayRate: Double,
+        reportsGeneratedCount: Int,
+        zoneId: ZoneId,
+        now: Instant,
+    ): List<String> {
+        val insights = mutableListOf<String>()
+        val today = now.atZone(zoneId).toLocalDate()
+
+        // 1) Days since last expense (all-time)
+        val lastExpenseMillis = allExpensesAllTime.maxOfOrNull { it.expense.date }
+        if (lastExpenseMillis != null) {
+            val lastDate = Instant.ofEpochMilli(lastExpenseMillis).atZone(zoneId).toLocalDate()
+            val days = java.time.temporal.ChronoUnit.DAYS.between(lastDate, today).toInt().coerceAtLeast(0)
+            insights.add(
+                when (days) {
+                    0 -> "You registered an expense today"
+                    1 -> "1 day since your last registered expense"
+                    else -> "$days days since your last registered expense"
+                }
+            )
+        }
+
+        // 2) OCR usage rate (period)
+        val ocrCount = periodExpenses.count { it.expense.source.name == "OCR" }
+        val totalCount = periodExpenses.size
+        if (totalCount > 0) {
+            val pct = ((ocrCount.toDouble() / totalCount.toDouble()) * 100.0).roundToInt()
+            insights.add("$pct% of expenses in this period were captured with OCR scanning ($ocrCount of $totalCount)")
+        }
+
+        // 3) Most common registration time (period)
+        if (periodExpenses.isNotEmpty()) {
+            val hourCounts = mutableMapOf<Int, Int>()
+            periodExpenses.forEach { ewl ->
+                val h = parseHour(ewl.expense.time) ?: return@forEach
+                hourCounts[h] = (hourCounts[h] ?: 0) + 1
+            }
+            val mostHour = hourCounts.maxByOrNull { it.value }?.key
+            if (mostHour != null) {
+                insights.add("Most common registration time in this period: ${formatHourOfDay(mostHour)}")
+            }
+        }
+
+        // 4) Small recurring expenses last 3 months (all-time)
+        val threeMonthsAgo = Calendar.getInstance().apply {
+            timeInMillis = now.toEpochMilli()
+            add(Calendar.MONTH, -3)
+        }.timeInMillis
+        val smallRecurring = allExpensesAllTime
+            .map { it.expense }
+            .filter { it.isRecurring && it.amount < SMALL_RECURRING_THRESHOLD_COP && it.date in threeMonthsAgo..now.toEpochMilli() }
+        if (smallRecurring.isNotEmpty()) {
+            insights.add("${smallRecurring.size} small recurring expenses in the last 3 months")
+        }
+
+        // 5) Highest single expense in period
+        val highest = periodExpenses.maxByOrNull { it.expense.amount }
+        if (highest != null) {
+            val name = highest.expense.name.ifBlank { "Unnamed expense" }
+            insights.add("Highest expense: $name — ${formatCurrency(highest.expense.amount, displayCurrency, displayRate)}")
+        }
+
+        // 6) Micro-purchases in period (< 5,000 COP equivalent)
+        val microThresholdDisplay = MICRO_PURCHASE_THRESHOLD_COP * displayRate
+        val microCount = periodExpenses.count { it.expense.amount < MICRO_PURCHASE_THRESHOLD_COP }
+        if (microCount > 0) {
+            insights.add("$microCount small purchases under ${formatCurrencyValue(microThresholdDisplay, displayCurrency)} in this period")
+        }
+
+        // 7) Average daily spending in period
+        val totalCop = periodExpenses.sumOf { it.expense.amount }
+        val days = max(1, java.time.temporal.ChronoUnit.DAYS.between(startDate, endDate).toInt() + 1)
+        if (totalCop > 0) {
+            val avgCop = totalCop / days
+            insights.add("Average daily spending: ${formatCurrency(avgCop, displayCurrency, displayRate)}")
+        }
+
+        // Bonus: reports generated counter
+        if (reportsGeneratedCount > 0) {
+            insights.add("You have generated $reportsGeneratedCount reports so far")
+        }
+
+        return insights
+    }
+
+    private fun parseHour(timeStr: String): Int? = try {
+        val cleaned = timeStr.trim().uppercase(Locale.US)
+        val isPm = cleaned.contains("PM")
+        val noPeriod = cleaned.replace("AM", "").replace("PM", "").trim()
+        val parts = noPeriod.split(":")
+        var hour = parts[0].trim().toInt()
+        if (isPm && hour != 12) hour += 12
+        if (!isPm && hour == 12) hour = 0
+        hour
+    } catch (_: Exception) {
+        null
+    }
+
+    private fun formatHourOfDay(hour: Int): String {
+        val period = if (hour < 12) "AM" else "PM"
+        val h12 = when {
+            hour == 0 -> 12
+            hour > 12 -> hour - 12
+            else -> hour
+        }
+        return "$h12:00 $period"
+    }
+
+    private fun formatPeriodLabel(start: LocalDate, end: LocalDate): String {
+        val sameYear = start.year == end.year
+        val monthDay = DateTimeFormatter.ofPattern("MMM d", Locale.ENGLISH)
+        val monthDayYear = DateTimeFormatter.ofPattern("MMM d, yyyy", Locale.ENGLISH)
+        val startStr = if (sameYear) start.format(monthDay) else start.format(monthDayYear)
+        val endStr = end.format(monthDayYear)
+        return "$startStr – $endStr"
+    }
+
+    private val largeFormatter = DecimalFormat("#,##0", DecimalFormatSymbols(Locale.US))
+    private val smallFormatter = DecimalFormat("0.##", DecimalFormatSymbols(Locale.US))
+
+    private fun formatCurrencyValue(value: Double, currency: String): String {
+        val v = if (value >= 10.0) largeFormatter.format(value)
+                else smallFormatter.format(value).trimEnd('0').trimEnd('.')
+        return "$currency $v"
+    }
+
+    private fun formatCurrency(amountCop: Double, currency: String, rate: Double): String {
+        return formatCurrencyValue(amountCop * rate, currency)
+    }
+}

--- a/app/src/main/java/com/example/spendantt/data/report/ReportPdfGenerator.kt
+++ b/app/src/main/java/com/example/spendantt/data/report/ReportPdfGenerator.kt
@@ -1,0 +1,494 @@
+package com.example.spendantt.data.report
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.RectF
+import android.graphics.Typeface
+import android.graphics.pdf.PdfDocument
+import androidx.core.content.res.ResourcesCompat
+import com.example.spendantt.R
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileOutputStream
+import java.text.DecimalFormat
+import java.text.DecimalFormatSymbols
+import java.text.SimpleDateFormat
+import java.time.format.DateTimeFormatter
+import java.util.Date
+import java.util.Locale
+import kotlin.math.max
+
+/**
+ * Generates a multi-page A4 PDF for a [FinancialReport].
+ *
+ * Layout philosophy:
+ *  - Reserved widths so amounts never collide with names or category bars.
+ *  - Wrap expense names to at most 2 lines.
+ *  - Per-page header (logo + "SpendAnt" + period) and footer (separator + generated stamp).
+ *  - ensureSpace() opens a new page when a block doesn't fit.
+ */
+class ReportPdfGenerator(private val context: Context) {
+
+    // A4 portrait in points
+    private val pageWidth = 595
+    private val pageHeight = 842
+
+    private val marginH = 36f
+    private val headerHeight = 76f
+    private val footerHeight = 40f
+
+    private val contentLeft = marginH
+    private val contentRight get() = pageWidth - marginH
+    private val contentTop get() = headerHeight + 18f
+    private val contentBottom get() = pageHeight - footerHeight
+
+    // Palette
+    private val brandGreen = Color.parseColor("#44C669")
+    private val brandPastel = Color.parseColor("#E0FFE9")
+    private val grayText = Color.parseColor("#5E5E5E")
+    private val redAmount = Color.parseColor("#F04C4C")
+    private val faintLine = Color.parseColor("#E0E0E0")
+    private val categoryColors = listOf(
+        Color.parseColor("#44C669"),
+        Color.parseColor("#4FC3F7"),
+        Color.parseColor("#BA68C8"),
+        Color.parseColor("#FF8A65"),
+        Color.parseColor("#AED581"),
+    )
+
+    private val displayCurrencyFormatterLarge = DecimalFormat("#,##0", DecimalFormatSymbols(Locale.US))
+    private val displayCurrencyFormatterSmall = DecimalFormat("#,##0.00", DecimalFormatSymbols(Locale.US))
+
+    // Holds mutable rendering state for the current PDF document.
+    private class PageContext(
+        val document: PdfDocument,
+        val report: FinancialReport,
+    ) {
+        var pageNumber: Int = 0
+        var page: PdfDocument.Page? = null
+        var canvas: Canvas? = null
+        var cursorY: Float = 0f
+    }
+
+    suspend fun generate(report: FinancialReport): File = withContext(Dispatchers.IO) {
+        val pdf = PdfDocument()
+        val ctx = PageContext(pdf, report)
+        openNewPage(ctx)
+
+        drawTotalCard(ctx)
+        drawDailyHistogram(ctx)
+        drawTopExpenses(ctx)
+        drawTopCategories(ctx)
+        drawInsights(ctx)
+
+        closeCurrentPage(ctx)
+
+        val file = outputFile(report)
+        FileOutputStream(file).use { pdf.writeTo(it) }
+        pdf.close()
+        file
+    }
+
+    // ── Page lifecycle ───────────────────────────────────────────────────────
+
+    private fun openNewPage(ctx: PageContext) {
+        ctx.pageNumber += 1
+        val info = PdfDocument.PageInfo.Builder(pageWidth, pageHeight, ctx.pageNumber).create()
+        val page = ctx.document.startPage(info)
+        ctx.page = page
+        ctx.canvas = page.canvas
+        drawHeader(ctx)
+        drawFooter(ctx)
+        ctx.cursorY = contentTop
+    }
+
+    private fun closeCurrentPage(ctx: PageContext) {
+        ctx.page?.let { ctx.document.finishPage(it) }
+        ctx.page = null
+        ctx.canvas = null
+    }
+
+    private fun ensureSpace(ctx: PageContext, requiredHeight: Float) {
+        if (ctx.cursorY + requiredHeight > contentBottom) {
+            closeCurrentPage(ctx)
+            openNewPage(ctx)
+        }
+    }
+
+    // ── Header / Footer ──────────────────────────────────────────────────────
+
+    private fun drawHeader(ctx: PageContext) {
+        val canvas = ctx.canvas ?: return
+        val bgPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { color = brandGreen }
+        canvas.drawRect(0f, 0f, pageWidth.toFloat(), headerHeight, bgPaint)
+
+        // Logo on the left, drawn directly on the green band (no separate circle bg).
+        val logoSize = 44
+        val logoLeft = marginH.toInt()
+        val logoTop = ((headerHeight - logoSize) / 2f).toInt()
+        runCatching {
+            val drawable = ResourcesCompat.getDrawable(
+                context.resources,
+                R.drawable.spendant_logo,
+                context.theme,
+            )
+            drawable?.setBounds(logoLeft, logoTop, logoLeft + logoSize, logoTop + logoSize)
+            drawable?.draw(canvas)
+        }
+
+        // Title block right of the logo
+        val titleX = logoLeft + logoSize + 12f
+        val titlePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = Color.WHITE
+            typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
+            textSize = 20f
+        }
+        val subPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = Color.WHITE
+            typeface = Typeface.DEFAULT
+            textSize = 10f
+        }
+        val titleY = headerHeight / 2f - 2f
+        canvas.drawText("SpendAnt", titleX, titleY, titlePaint)
+        canvas.drawText("Financial Report", titleX, titleY + 14f, subPaint)
+
+        // Period right-aligned
+        val periodPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = Color.WHITE
+            typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
+            textSize = 12f
+            textAlign = Paint.Align.RIGHT
+        }
+        canvas.drawText(ctx.report.periodLabel, contentRight, headerHeight / 2f + 4f, periodPaint)
+    }
+
+    private fun drawFooter(ctx: PageContext) {
+        val canvas = ctx.canvas ?: return
+        val linePaint = Paint().apply { color = faintLine; strokeWidth = 1f }
+        val lineY = pageHeight - footerHeight + 6f
+        canvas.drawLine(contentLeft, lineY, contentRight, lineY, linePaint)
+
+        val stamp = SimpleDateFormat("MMM d, yyyy 'at' HH:mm", Locale.ENGLISH)
+            .format(Date(ctx.report.generatedAt))
+        val text = "Generated by SpendAnt | $stamp"
+
+        val paint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = grayText
+            textSize = 9f
+            textAlign = Paint.Align.CENTER
+        }
+        canvas.drawText(text, pageWidth / 2f, lineY + 18f, paint)
+    }
+
+    // ── Sections ─────────────────────────────────────────────────────────────
+
+    private fun drawTotalCard(ctx: PageContext) {
+        val canvas = ctx.canvas ?: return
+        val cardHeight = 64f
+        ensureSpace(ctx, cardHeight + 18f)
+
+        val rect = RectF(contentLeft, ctx.cursorY, contentRight, ctx.cursorY + cardHeight)
+        val bgPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { color = brandPastel }
+        canvas.drawRoundRect(rect, 8f, 8f, bgPaint)
+
+        val labelPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = grayText
+            textSize = 10f
+        }
+        canvas.drawText("Total spent", rect.left + 14f, rect.top + 22f, labelPaint)
+
+        val amountPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = Color.BLACK
+            typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
+            textSize = 22f
+        }
+        canvas.drawText(
+            formatDisplayAmount(ctx.report.totalSpentCop, ctx.report),
+            rect.left + 14f,
+            rect.top + 48f,
+            amountPaint,
+        )
+        ctx.cursorY += cardHeight + 18f
+    }
+
+    private fun drawDailyHistogram(ctx: PageContext) {
+        val canvas = ctx.canvas ?: return
+        val report = ctx.report
+        if (report.dailySpends.isEmpty()) return
+
+        val titleHeight = 22f
+        val chartHeight = 110f
+        val labelStripHeight = 16f
+        val total = titleHeight + chartHeight + labelStripHeight + 14f
+        ensureSpace(ctx, total)
+
+        drawSectionTitle(ctx, "Daily Spending")
+        val chartTop = ctx.cursorY
+        val chartBottom = chartTop + chartHeight
+        val axisY = chartBottom
+
+        val maxAmount = report.dailySpends.maxOf { it.amountCop }.coerceAtLeast(1.0)
+        val barAreaLeft = contentLeft
+        val barAreaRight = contentRight
+        val available = barAreaRight - barAreaLeft
+        val n = report.dailySpends.size
+        val spacing = 4f
+        val barWidth = max(2f, (available - spacing * (n - 1)) / n)
+
+        val barPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { color = brandGreen }
+        val axisPaint = Paint().apply { color = faintLine; strokeWidth = 1f }
+        canvas.drawLine(barAreaLeft, axisY, barAreaRight, axisY, axisPaint)
+
+        report.dailySpends.forEachIndexed { index, ds ->
+            val ratio = (ds.amountCop / maxAmount).toFloat().coerceIn(0f, 1f)
+            val h = ratio * (chartHeight - 6f)
+            val x = barAreaLeft + index * (barWidth + spacing)
+            val top = axisY - h
+            canvas.drawRoundRect(RectF(x, top, x + barWidth, axisY), 2f, 2f, barPaint)
+        }
+
+        val labelPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = grayText
+            textSize = 8f
+            textAlign = Paint.Align.CENTER
+        }
+        val maxLabels = 6
+        val step = max(1, n / maxLabels)
+        report.dailySpends.forEachIndexed { index, ds ->
+            if (index % step == 0) {
+                val x = barAreaLeft + index * (barWidth + spacing) + barWidth / 2f
+                canvas.drawText(ds.date.dayOfMonth.toString(), x, axisY + 12f, labelPaint)
+            }
+        }
+
+        ctx.cursorY = chartBottom + labelStripHeight + 14f
+    }
+
+    private fun drawTopExpenses(ctx: PageContext) {
+        val canvas = ctx.canvas ?: return
+        if (ctx.report.topExpenses.isEmpty()) return
+        drawSectionTitle(ctx, "Top Expenses")
+
+        // Reserve a fixed amount column on the right so names never collide with the price.
+        val amountColumnWidth = 110f
+        val rowGap = 6f
+
+        val namePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = Color.BLACK
+            typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
+            textSize = 12f
+        }
+        val subPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = grayText
+            textSize = 9f
+        }
+        val amountPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = redAmount
+            typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
+            textSize = 12f
+            textAlign = Paint.Align.RIGHT
+        }
+        val bgPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { color = brandPastel }
+
+        ctx.report.topExpenses.forEach { expense ->
+            val nameMaxWidth = (contentRight - contentLeft) - amountColumnWidth - 28f
+            val nameLines = wrapText(expense.name.ifBlank { "Unnamed expense" }, namePaint, nameMaxWidth, maxLines = 2)
+            // Row height: paddingTop + nameLines * 16 + 4 + subline 12 + paddingBottom
+            val rowHeight = 14f + nameLines.size * 16f + 4f + 12f + 12f
+
+            ensureSpace(ctx, rowHeight + rowGap)
+            val rect = RectF(contentLeft, ctx.cursorY, contentRight, ctx.cursorY + rowHeight)
+            canvas.drawRoundRect(rect, 8f, 8f, bgPaint)
+
+            // Draw each name line explicitly to avoid clipping
+            val nameLeftX = rect.left + 14f
+            var lineY = rect.top + 18f
+            nameLines.forEach { line ->
+                canvas.drawText(line, nameLeftX, lineY, namePaint)
+                lineY += 16f
+            }
+
+            // Subline: category | date
+            val dateStr = expense.date.format(DateTimeFormatter.ofPattern("MMM d, yyyy", Locale.ENGLISH))
+            canvas.drawText("${expense.category}  |  $dateStr", nameLeftX, lineY + 4f, subPaint)
+
+            // Amount right-aligned, vertically centered-ish
+            val amountY = rect.top + rowHeight / 2f + 4f
+            canvas.drawText(
+                formatDisplayAmount(expense.amountCop, ctx.report),
+                rect.right - 14f,
+                amountY,
+                amountPaint,
+            )
+
+            ctx.cursorY += rowHeight + rowGap
+        }
+        ctx.cursorY += 8f
+    }
+
+    private fun drawTopCategories(ctx: PageContext) {
+        val canvas = ctx.canvas ?: return
+        if (ctx.report.topCategories.isEmpty()) return
+        drawSectionTitle(ctx, "Top Categories")
+
+        val labelPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = Color.BLACK
+            textSize = 11f
+            typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
+        }
+        val amountPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = grayText
+            textSize = 10f
+        }
+        val total = ctx.report.topCategories.sumOf { it.amountCop }.coerceAtLeast(1.0)
+
+        // Fixed reserved widths so the bar can never overlap label or amount.
+        val labelColumnWidth = 110f
+        val amountColumnWidth = 110f
+        val barGapLeft = 8f
+        val barGapRight = 4f
+        val rowHeight = 26f
+
+        ctx.report.topCategories.forEachIndexed { idx, category ->
+            ensureSpace(ctx, rowHeight)
+
+            val rowTop = ctx.cursorY
+            val centerY = rowTop + rowHeight / 2f + 4f // rough baseline
+
+            // Label (truncated to fit its reserved column)
+            val labelText = ellipsize(category.label, labelPaint, labelColumnWidth - 6f)
+            canvas.drawText(labelText, contentLeft, centerY, labelPaint)
+
+            // Amount, placed right after the label column (before the bar)
+            val amountText = formatDisplayAmount(category.amountCop, ctx.report)
+            val amountText2 = ellipsize(amountText, amountPaint, amountColumnWidth - 6f)
+            canvas.drawText(amountText2, contentLeft + labelColumnWidth, centerY, amountPaint)
+
+            // Bar fills the remaining horizontal space
+            val barLeft = contentLeft + labelColumnWidth + amountColumnWidth + barGapLeft
+            val barRight = contentRight - barGapRight
+            val barTrackPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { color = faintLine }
+            val barFillPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                color = categoryColors[idx % categoryColors.size]
+            }
+            val trackRect = RectF(barLeft, rowTop + 8f, barRight, rowTop + 18f)
+            canvas.drawRoundRect(trackRect, 5f, 5f, barTrackPaint)
+            val ratio = (category.amountCop / total).toFloat().coerceIn(0f, 1f)
+            val fillRight = barLeft + (barRight - barLeft) * ratio
+            if (fillRight > barLeft) {
+                canvas.drawRoundRect(RectF(barLeft, rowTop + 8f, fillRight, rowTop + 18f), 5f, 5f, barFillPaint)
+            }
+
+            ctx.cursorY += rowHeight
+        }
+        ctx.cursorY += 12f
+    }
+
+    private fun drawInsights(ctx: PageContext) {
+        if (ctx.report.bqInsights.isEmpty()) return
+        val canvas = ctx.canvas ?: return
+        drawSectionTitle(ctx, "Insights")
+
+        val bullet = "•"
+        val paint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = Color.BLACK
+            textSize = 11f
+        }
+        val bulletPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = grayText
+            textSize = 12f
+            typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
+        }
+        val lineHeight = 16f
+        val bulletInset = 14f
+
+        ctx.report.bqInsights.forEach { insight ->
+            val maxWidth = contentRight - contentLeft - bulletInset
+            val lines = wrapText(insight, paint, maxWidth, maxLines = 4)
+            val blockHeight = lines.size * lineHeight + 4f
+            ensureSpace(ctx, blockHeight)
+
+            canvas.drawText(bullet, contentLeft, ctx.cursorY + 12f, bulletPaint)
+            var lineY = ctx.cursorY + 12f
+            lines.forEach {
+                canvas.drawText(it, contentLeft + bulletInset, lineY, paint)
+                lineY += lineHeight
+            }
+            ctx.cursorY += blockHeight
+        }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private fun drawSectionTitle(ctx: PageContext, title: String) {
+        val canvas = ctx.canvas ?: return
+        val paint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = Color.BLACK
+            typeface = Typeface.create(Typeface.DEFAULT, Typeface.BOLD)
+            textSize = 14f
+        }
+        ensureSpace(ctx, 24f)
+        canvas.drawText(title, contentLeft, ctx.cursorY + 14f, paint)
+        ctx.cursorY += 22f
+    }
+
+    private fun wrapText(text: String, paint: Paint, maxWidth: Float, maxLines: Int): List<String> {
+        if (text.isEmpty()) return listOf("")
+        val words = text.split(" ")
+        val lines = mutableListOf<String>()
+        var current = StringBuilder()
+        words.forEach { word ->
+            val candidate = if (current.isEmpty()) word else "$current $word"
+            if (paint.measureText(candidate) <= maxWidth) {
+                current = StringBuilder(candidate)
+            } else {
+                if (current.isNotEmpty()) lines.add(current.toString())
+                current = StringBuilder(word)
+                if (lines.size == maxLines - 1) {
+                    // Last allowed line — truncate the remainder
+                    val remaining = (listOf(word) + words.drop(words.indexOf(word) + 1)).joinToString(" ")
+                    lines.add(ellipsize(remaining, paint, maxWidth))
+                    return lines
+                }
+            }
+        }
+        if (current.isNotEmpty()) lines.add(current.toString())
+        if (lines.size > maxLines) {
+            val truncated = lines.take(maxLines).toMutableList()
+            truncated[maxLines - 1] = ellipsize(truncated[maxLines - 1] + " " + lines.drop(maxLines).joinToString(" "), paint, maxWidth)
+            return truncated
+        }
+        return lines
+    }
+
+    private fun ellipsize(text: String, paint: Paint, maxWidth: Float): String {
+        if (paint.measureText(text) <= maxWidth) return text
+        val ellipsis = "…"
+        var end = text.length
+        while (end > 0 && paint.measureText(text.substring(0, end) + ellipsis) > maxWidth) {
+            end -= 1
+        }
+        return if (end <= 0) ellipsis else text.substring(0, end) + ellipsis
+    }
+
+    private fun formatDisplayAmount(amountCop: Double, report: FinancialReport): String {
+        val value = amountCop * report.displayRate
+        val formatted = if (value >= 100) displayCurrencyFormatterLarge.format(value)
+                        else displayCurrencyFormatterSmall.format(value)
+        return "${report.displayCurrency} $formatted"
+    }
+
+    private fun outputFile(report: FinancialReport): File {
+        // App-scoped external storage works across all Android versions without
+        // additional permissions and is exposed to other apps via FileProvider.
+        val base = context.getExternalFilesDir(android.os.Environment.DIRECTORY_DOWNLOADS)
+            ?: context.filesDir
+        if (!base.exists()) base.mkdirs()
+        val stamp = SimpleDateFormat("yyyyMMdd_HHmm", Locale.US).format(Date(report.generatedAt))
+        val name = "SpendAnt_Report_${stamp}.pdf"
+        return File(base, name)
+    }
+}

--- a/app/src/main/java/com/example/spendantt/data/report/ReportRepository.kt
+++ b/app/src/main/java/com/example/spendantt/data/report/ReportRepository.kt
@@ -1,0 +1,122 @@
+package com.example.spendantt.data.report
+
+import android.content.Context
+import com.example.spendantt.data.local.AppDatabase
+import com.example.spendantt.data.local.entity.ReportCacheEntity
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+import java.time.LocalDate
+
+class ReportRepository(private val appContext: Context) {
+
+    private val db = AppDatabase.getInstance(appContext)
+    private val prefs by lazy {
+        appContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    }
+
+    /** Returns the cached report when it exists and is younger than [TTL_MILLIS]. */
+    suspend fun getCached(userId: Int, start: LocalDate, end: LocalDate): FinancialReport? = withContext(Dispatchers.IO) {
+        val key = buildKey(userId, start, end)
+        val row = db.reportCacheDao().getByKey(key) ?: return@withContext null
+        val age = System.currentTimeMillis() - row.generatedAt
+        if (age > TTL_MILLIS) {
+            db.reportCacheDao().delete(key)
+            return@withContext null
+        }
+        runCatching { FinancialReportJson.decode(row.reportJson) }.getOrNull()
+    }
+
+    /** Returns the cache row (without parsing) when valid — useful to show "tap to open" hints. */
+    suspend fun peekCacheRow(userId: Int, start: LocalDate, end: LocalDate): ReportCacheEntity? = withContext(Dispatchers.IO) {
+        val key = buildKey(userId, start, end)
+        val row = db.reportCacheDao().getByKey(key) ?: return@withContext null
+        if (System.currentTimeMillis() - row.generatedAt > TTL_MILLIS) {
+            db.reportCacheDao().delete(key)
+            null
+        } else row
+    }
+
+    /** Recent reports for the user (within the TTL window). */
+    suspend fun getRecentReports(userId: Int): List<ReportCacheEntity> = withContext(Dispatchers.IO) {
+        val since = System.currentTimeMillis() - TTL_MILLIS
+        db.reportCacheDao().deleteOlderThan(since)
+        db.reportCacheDao().getRecentForUser(userId, since)
+    }
+
+    suspend fun decodeRow(row: ReportCacheEntity): FinancialReport? = withContext(Dispatchers.Default) {
+        runCatching { FinancialReportJson.decode(row.reportJson) }.getOrNull()
+    }
+
+    /**
+     * Generates a new report and persists it to the cache.
+     * The heavy work runs on [Dispatchers.Default] so the UI thread stays responsive.
+     */
+    suspend fun generate(
+        userId: Int,
+        start: LocalDate,
+        end: LocalDate,
+        displayCurrency: String,
+        displayRate: Double,
+    ): FinancialReport {
+        val allExpenses = withContext(Dispatchers.IO) {
+            db.expenseDao().getExpensesWithLabels(userId).first()
+        }
+
+        val newCount = bumpUsageCounter(userId)
+
+        val report = withContext(Dispatchers.Default) {
+            ReportAggregator.build(
+                allExpensesAllTime = allExpenses,
+                startDate = start,
+                endDate = end,
+                displayCurrency = displayCurrency,
+                displayRate = displayRate,
+                reportsGeneratedCount = newCount,
+            )
+        }
+
+        withContext(Dispatchers.IO) {
+            val json = FinancialReportJson.encode(report)
+            db.reportCacheDao().upsert(
+                ReportCacheEntity(
+                    cacheKey = buildKey(userId, start, end),
+                    userId = userId,
+                    startEpochDay = start.toEpochDay(),
+                    endEpochDay = end.toEpochDay(),
+                    reportJson = json,
+                    generatedAt = report.generatedAt,
+                )
+            )
+        }
+        return report
+    }
+
+    /** Returns the smallest first-expense date for the user, or null. */
+    suspend fun getFirstExpenseDate(userId: Int): LocalDate? = withContext(Dispatchers.IO) {
+        val expenses = db.expenseDao().getExpensesWithLabels(userId).first()
+        expenses.minOfOrNull { it.expense.date }
+            ?.let { java.time.Instant.ofEpochMilli(it).atZone(java.time.ZoneId.systemDefault()).toLocalDate() }
+    }
+
+    private fun bumpUsageCounter(userId: Int): Int {
+        val key = "$USAGE_KEY_PREFIX$userId"
+        val current = prefs.getInt(key, 0)
+        val updated = current + 1
+        prefs.edit().putInt(key, updated).apply()
+        return updated
+    }
+
+    fun getUsageCount(userId: Int): Int =
+        prefs.getInt("$USAGE_KEY_PREFIX$userId", 0)
+
+    companion object {
+        private const val PREFS_NAME = "report_prefs"
+        private const val USAGE_KEY_PREFIX = "report_usage_"
+        private const val TTL_MILLIS = 24L * 60L * 60L * 1000L
+
+        fun buildKey(userId: Int, start: LocalDate, end: LocalDate): String {
+            return "${userId}_${start}_$end"
+        }
+    }
+}

--- a/app/src/main/java/com/example/spendantt/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/spendantt/ui/navigation/AppNavigation.kt
@@ -37,7 +37,9 @@ import com.example.spendantt.ui.screens.expense.NewExpenseScreen
 import com.example.spendantt.ui.screens.goal.GoalsRoute
 import com.example.spendantt.ui.screens.home.HomeScreen
 import com.example.spendantt.ui.screens.notifications.NotificationsScreen
+import com.example.spendantt.ui.screens.report.ReportFlowScreen
 import com.example.spendantt.viewmodel.BudgetViewModel
+import com.example.spendantt.viewmodel.ReportViewModel
 import com.example.spendantt.viewmodel.GoalsViewModel
 import com.example.spendantt.viewmodel.HomeViewModel
 import com.example.spendantt.viewmodel.LoginViewModel
@@ -66,6 +68,7 @@ sealed class Screen(val route: String) {
     object NewExpense : Screen("new_expense")
     object ExpenseDetail : Screen("expense_detail")
     object Notifications : Screen("notifications")
+    object Report : Screen("report")
 }
 
 private val routesWithoutNavBar = listOf(
@@ -81,7 +84,8 @@ private val routesWithoutNavBar = listOf(
     Screen.NewExpense.route,
     Screen.ExpenseDetail.route,
     Screen.EditProfile.route,
-    Screen.Notifications.route
+    Screen.Notifications.route,
+    Screen.Report.route
 )
 
 @Composable
@@ -334,7 +338,19 @@ fun AppNavigation(
                     onIncomeClick = { navController.navigate(Screen.Budget.route) },
                     onGoalsClick = { navController.navigate(Screen.Goals.route) },
                     onCurrencyClick = { navController.navigate(Screen.CurrencyConverter.route) },
-                    onEditClick = { navController.navigate(Screen.EditProfile.route) }
+                    onEditClick = { navController.navigate(Screen.EditProfile.route) },
+                    onSummaryClick = { navController.navigate(Screen.Report.route) }
+                )
+            }
+
+            composable(Screen.Report.route) {
+                if (currentUserId == null) return@composable
+                val reportViewModel = remember(currentUserId) {
+                    ReportViewModel(context, currentUserId)
+                }
+                ReportFlowScreen(
+                    viewModel = reportViewModel,
+                    onExit = { navController.popBackStack() },
                 )
             }
 

--- a/app/src/main/java/com/example/spendantt/ui/screens/budget/BudgetNavigation.kt
+++ b/app/src/main/java/com/example/spendantt/ui/screens/budget/BudgetNavigation.kt
@@ -42,7 +42,8 @@ fun BudgetNavigation(
                 onIncomeClick = { currentScreen = BudgetScreen.BUDGET_AND_INCOME },
                 onGoalsClick = onGoalsClick,
                 onCurrencyClick = {},
-                onEditClick = { /* TODO: EditProfileScreen */ }
+                onEditClick = { /* TODO: EditProfileScreen */ },
+                onSummaryClick = {}
             )
         }
 

--- a/app/src/main/java/com/example/spendantt/ui/screens/budget/ProfileScreen.kt
+++ b/app/src/main/java/com/example/spendantt/ui/screens/budget/ProfileScreen.kt
@@ -69,6 +69,7 @@ fun ProfileScreen(
     onGoalsClick: () -> Unit,
     onCurrencyClick: () -> Unit,
     onEditClick: () -> Unit,
+    onSummaryClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val exportResult by viewModel.exportResult.collectAsState()
@@ -205,7 +206,7 @@ fun ProfileScreen(
                 ProfileActionButton(
                     icon = Icons.AutoMirrored.Filled.Article,
                     label = "Summary",
-                    onClick = { viewModel.exportUserData(context) },
+                    onClick = onSummaryClick,
                     modifier = Modifier.weight(1f)
                 )
             }

--- a/app/src/main/java/com/example/spendantt/ui/screens/report/ReportFlowScreen.kt
+++ b/app/src/main/java/com/example/spendantt/ui/screens/report/ReportFlowScreen.kt
@@ -1,0 +1,35 @@
+package com.example.spendantt.ui.screens.report
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import com.example.spendantt.viewmodel.ReportViewModel
+
+/**
+ * Single-route container that toggles between the setup and the report view
+ * depending on whether a report has been opened.
+ */
+@Composable
+fun ReportFlowScreen(
+    viewModel: ReportViewModel,
+    onExit: () -> Unit,
+) {
+    val report by viewModel.currentReport.collectAsState()
+
+    BackHandler(enabled = report != null) {
+        viewModel.closeReport()
+    }
+
+    if (report == null) {
+        ReportSetupScreen(
+            viewModel = viewModel,
+            onClose = onExit,
+        )
+    } else {
+        ReportViewScreen(
+            viewModel = viewModel,
+            onClose = { viewModel.closeReport() },
+        )
+    }
+}

--- a/app/src/main/java/com/example/spendantt/ui/screens/report/ReportSetupScreen.kt
+++ b/app/src/main/java/com/example/spendantt/ui/screens/report/ReportSetupScreen.kt
@@ -1,0 +1,305 @@
+package com.example.spendantt.ui.screens.report
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Article
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.CalendarMonth
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.PictureAsPdf
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDefaults
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.spendantt.data.local.entity.ReportCacheEntity
+import com.example.spendantt.ui.theme.SpendAntBlack
+import com.example.spendantt.ui.theme.SpendAntGreen
+import com.example.spendantt.ui.theme.SpendAntTextSecondary
+import com.example.spendantt.ui.theme.SpendAntWhite
+import com.example.spendantt.viewmodel.ReportViewModel
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+private val FieldBg = Color(0xFFE0FFE9)
+private val GrayText = Color(0xFF5E5E5E)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ReportSetupScreen(
+    viewModel: ReportViewModel,
+    onClose: () -> Unit,
+) {
+    val state by viewModel.setup.collectAsState()
+
+    var showStartPicker by remember { mutableStateOf(false) }
+    var showEndPicker by remember { mutableStateOf(false) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(SpendAntWhite),
+    ) {
+        // Header
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(SpendAntGreen)
+                .padding(horizontal = 8.dp, vertical = 14.dp),
+        ) {
+            IconButton(onClick = onClose, modifier = Modifier.align(Alignment.CenterStart)) {
+                Icon(Icons.Default.Close, contentDescription = "Close", tint = Color.Black)
+            }
+            Text(
+                text = "Spending Report",
+                color = Color.Black,
+                fontWeight = FontWeight.Bold,
+                fontSize = 18.sp,
+                modifier = Modifier.align(Alignment.Center),
+            )
+        }
+
+        Column(
+            modifier = Modifier
+                .verticalScroll(rememberScrollState())
+                .padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = "Select period",
+                color = SpendAntBlack,
+                fontWeight = FontWeight.Bold,
+                fontSize = 16.sp,
+            )
+
+            DateField(
+                label = "Start",
+                date = state.startDate,
+                onClick = { showStartPicker = true },
+            )
+
+            DateField(
+                label = "End",
+                date = state.endDate,
+                onClick = { showEndPicker = true },
+            )
+
+            val cachedRow = state.cachedRowForCurrentRange
+            if (cachedRow != null) {
+                ViewThisReportCard(
+                    row = cachedRow,
+                    onClick = { viewModel.openCached(cachedRow) },
+                )
+            }
+
+            Spacer(modifier = Modifier.height(4.dp))
+
+            Button(
+                onClick = { viewModel.generate() },
+                enabled = !state.isGenerating,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = SpendAntBlack,
+                    contentColor = SpendAntWhite,
+                ),
+                shape = RoundedCornerShape(10.dp),
+                contentPadding = PaddingValues(vertical = 14.dp),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                if (state.isGenerating) {
+                    CircularProgressIndicator(color = Color.White, strokeWidth = 2.dp, modifier = Modifier.size(18.dp))
+                } else {
+                    Icon(Icons.Default.PictureAsPdf, contentDescription = null, modifier = Modifier.size(18.dp))
+                    Spacer(modifier = Modifier.size(8.dp))
+                    Text(text = "Generate Report", fontWeight = FontWeight.Bold)
+                }
+            }
+
+            val others = state.recentReports.filter {
+                it.startEpochDay != state.startDate.toEpochDay() ||
+                    it.endEpochDay != state.endDate.toEpochDay()
+            }
+            if (others.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = "Other recent reports",
+                    color = GrayText,
+                    fontSize = 13.sp,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    others.forEach { row ->
+                        RecentReportCard(
+                            row = row,
+                            onClick = { viewModel.openCached(row) },
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    if (showStartPicker) {
+        val initial = state.startDate.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
+        val pickerState = rememberDatePickerState(initialSelectedDateMillis = initial)
+        DatePickerDialog(
+            onDismissRequest = { showStartPicker = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    pickerState.selectedDateMillis?.let { millis ->
+                        viewModel.onStartDateChange(ReportViewModel.millisToLocalDate(millis))
+                    }
+                    showStartPicker = false
+                }) { Text("OK", color = SpendAntGreen) }
+            },
+            dismissButton = {
+                TextButton(onClick = { showStartPicker = false }) {
+                    Text("Cancel", color = SpendAntTextSecondary)
+                }
+            },
+        ) {
+            DatePicker(
+                state = pickerState,
+                colors = DatePickerDefaults.colors(
+                    selectedDayContainerColor = SpendAntGreen,
+                    todayDateBorderColor = SpendAntGreen,
+                ),
+            )
+        }
+    }
+
+    if (showEndPicker) {
+        val initial = state.endDate.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
+        val pickerState = rememberDatePickerState(initialSelectedDateMillis = initial)
+        DatePickerDialog(
+            onDismissRequest = { showEndPicker = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    pickerState.selectedDateMillis?.let { millis ->
+                        viewModel.onEndDateChange(ReportViewModel.millisToLocalDate(millis))
+                    }
+                    showEndPicker = false
+                }) { Text("OK", color = SpendAntGreen) }
+            },
+            dismissButton = {
+                TextButton(onClick = { showEndPicker = false }) {
+                    Text("Cancel", color = SpendAntTextSecondary)
+                }
+            },
+        ) {
+            DatePicker(
+                state = pickerState,
+                colors = DatePickerDefaults.colors(
+                    selectedDayContainerColor = SpendAntGreen,
+                    todayDateBorderColor = SpendAntGreen,
+                ),
+            )
+        }
+    }
+}
+
+@Composable
+private fun DateField(label: String, date: LocalDate, onClick: () -> Unit) {
+    val text = date.format(DateTimeFormatter.ofPattern("EEE, MMM d yyyy", Locale.ENGLISH))
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(FieldBg, RoundedCornerShape(10.dp))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 14.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(Icons.Default.CalendarMonth, contentDescription = null, tint = GrayText, modifier = Modifier.size(20.dp))
+        Spacer(modifier = Modifier.size(10.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(text = label, color = GrayText, fontSize = 11.sp)
+            Text(text = text, color = SpendAntBlack, fontSize = 15.sp, fontWeight = FontWeight.Bold)
+        }
+        Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = null, tint = GrayText)
+    }
+}
+
+@Composable
+private fun ViewThisReportCard(row: ReportCacheEntity, onClick: () -> Unit) {
+    val time = java.text.SimpleDateFormat("HH:mm", Locale.getDefault()).format(java.util.Date(row.generatedAt))
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .border(BorderStroke(1.dp, SpendAntGreen), RoundedCornerShape(10.dp))
+            .background(Color(0x1A44C669), RoundedCornerShape(10.dp))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 14.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(Icons.Default.CheckCircle, contentDescription = null, tint = SpendAntGreen)
+        Spacer(modifier = Modifier.size(10.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(text = "View this report", color = SpendAntBlack, fontWeight = FontWeight.Bold, fontSize = 15.sp)
+            Text(text = "Generated at $time · tap to open", color = GrayText, fontSize = 11.sp)
+        }
+        Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = null, tint = SpendAntBlack)
+    }
+}
+
+@Composable
+private fun RecentReportCard(row: ReportCacheEntity, onClick: () -> Unit) {
+    val start = LocalDate.ofEpochDay(row.startEpochDay)
+    val end = LocalDate.ofEpochDay(row.endEpochDay)
+    val periodLabel = "${start.format(DateTimeFormatter.ofPattern("MMM d", Locale.ENGLISH))} – ${end.format(DateTimeFormatter.ofPattern("MMM d, yyyy", Locale.ENGLISH))}"
+    val time = java.text.SimpleDateFormat("HH:mm", Locale.getDefault()).format(java.util.Date(row.generatedAt))
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(FieldBg, RoundedCornerShape(10.dp))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 14.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(Icons.AutoMirrored.Filled.Article, contentDescription = null, tint = SpendAntBlack, modifier = Modifier.size(20.dp))
+        Spacer(modifier = Modifier.size(10.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(text = periodLabel, color = SpendAntBlack, fontWeight = FontWeight.Bold, fontSize = 14.sp)
+            Text(text = "Generated at $time", color = GrayText, fontSize = 11.sp)
+        }
+        Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = null, tint = GrayText)
+    }
+}
+

--- a/app/src/main/java/com/example/spendantt/ui/screens/report/ReportViewScreen.kt
+++ b/app/src/main/java/com/example/spendantt/ui/screens/report/ReportViewScreen.kt
@@ -1,0 +1,316 @@
+package com.example.spendantt.ui.screens.report
+
+import android.content.Context
+import android.content.Intent
+import android.widget.Toast
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Download
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.core.content.FileProvider
+import com.example.spendantt.data.report.CategoryTotal
+import com.example.spendantt.data.report.FinancialReport
+import com.example.spendantt.data.report.ReportPdfGenerator
+import com.example.spendantt.data.report.TopExpense
+import com.example.spendantt.ui.theme.SpendAntBlack
+import com.example.spendantt.ui.theme.SpendAntGreen
+import com.example.spendantt.viewmodel.ReportViewModel
+import kotlinx.coroutines.launch
+import java.io.File
+import java.text.DecimalFormat
+import java.text.DecimalFormatSymbols
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+private val PastelGreen = Color(0xFFE0FFE9)
+private val GrayText = Color(0xFF5E5E5E)
+private val AmountRed = Color(0xFFF04C4C)
+private val CategoryColors = listOf(
+    Color(0xFF44C669),
+    Color(0xFF4FC3F7),
+    Color(0xFFBA68C8),
+    Color(0xFFFF8A65),
+    Color(0xFFAED581),
+)
+
+@Composable
+fun ReportViewScreen(
+    viewModel: ReportViewModel,
+    onClose: () -> Unit,
+) {
+    val report by viewModel.currentReport.collectAsState()
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    var isExporting by remember { mutableStateOf(false) }
+
+    val r = report ?: return
+
+    Column(modifier = Modifier.fillMaxSize().background(Color.White)) {
+        // Header
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(SpendAntGreen)
+                .padding(horizontal = 8.dp, vertical = 14.dp),
+        ) {
+            IconButton(onClick = onClose, modifier = Modifier.align(Alignment.CenterStart)) {
+                Icon(Icons.Default.Close, contentDescription = "Close", tint = Color.Black)
+            }
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier.align(Alignment.Center),
+            ) {
+                Text(text = "Spending Report", color = Color.Black, fontWeight = FontWeight.Bold, fontSize = 18.sp)
+                Text(text = r.periodLabel, color = GrayText, fontSize = 11.sp)
+            }
+            IconButton(
+                onClick = {
+                    if (isExporting) return@IconButton
+                    isExporting = true
+                    scope.launch {
+                        try {
+                            val file = ReportPdfGenerator(context.applicationContext).generate(r)
+                            openPdf(context, file)
+                        } catch (e: Exception) {
+                            Toast.makeText(context, "Could not export PDF: ${e.message}", Toast.LENGTH_LONG).show()
+                        } finally {
+                            isExporting = false
+                        }
+                    }
+                },
+                modifier = Modifier.align(Alignment.CenterEnd),
+            ) {
+                Icon(Icons.Default.Download, contentDescription = "Download", tint = Color.Black)
+            }
+        }
+
+        LazyColumn(
+            modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            item { Spacer(modifier = Modifier.height(8.dp)) }
+            item { TotalCard(report = r) }
+            item { SectionTitle("Daily Spending") }
+            item { DailyHistogram(report = r) }
+            item { SectionTitle("Top Expenses") }
+            itemsIndexed(r.topExpenses) { _, exp -> TopExpenseRow(expense = exp, report = r) }
+            item { SectionTitle("Top Categories") }
+            itemsIndexed(r.topCategories) { index, cat ->
+                CategoryRow(cat = cat, total = r.topCategories.sumOf { it.amountCop }.coerceAtLeast(1.0), color = CategoryColors[index % CategoryColors.size], report = r)
+            }
+            if (r.bqInsights.isNotEmpty()) {
+                item { Spacer(modifier = Modifier.height(4.dp)) }
+                item { InsightsCard(insights = r.bqInsights) }
+            }
+            item { Spacer(modifier = Modifier.height(24.dp)) }
+        }
+    }
+}
+
+@Composable
+private fun SectionTitle(text: String) {
+    Text(
+        text = text,
+        color = SpendAntBlack,
+        fontWeight = FontWeight.Bold,
+        fontSize = 16.sp,
+        modifier = Modifier.padding(top = 8.dp),
+    )
+}
+
+@Composable
+private fun TotalCard(report: FinancialReport) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(10.dp))
+            .background(PastelGreen)
+            .padding(horizontal = 16.dp, vertical = 14.dp),
+    ) {
+        Text(text = "Total spent", color = GrayText, fontSize = 12.sp)
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text = formatDisplay(report.totalSpentCop, report),
+            color = SpendAntBlack,
+            fontWeight = FontWeight.Bold,
+            fontSize = 30.sp,
+        )
+    }
+}
+
+@Composable
+private fun DailyHistogram(report: FinancialReport) {
+    val daily = report.dailySpends
+    if (daily.isEmpty()) return
+    val maxAmount = daily.maxOf { it.amountCop }.coerceAtLeast(1.0)
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Canvas(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(120.dp),
+        ) {
+            val n = daily.size
+            val spacing = 6f
+            val available = size.width - spacing * (n - 1)
+            val barWidth = (available / n).coerceAtLeast(2f)
+            val baseY = size.height
+            daily.forEachIndexed { index, ds ->
+                val ratio = (ds.amountCop / maxAmount).toFloat().coerceIn(0f, 1f)
+                val barHeight = ratio * size.height
+                val x = index * (barWidth + spacing)
+                drawRect(
+                    color = SpendAntGreen,
+                    topLeft = Offset(x, baseY - barHeight),
+                    size = Size(barWidth, barHeight),
+                )
+            }
+        }
+        Row(modifier = Modifier.fillMaxWidth().padding(top = 4.dp)) {
+            val maxLabels = 6
+            val step = (daily.size / maxLabels).coerceAtLeast(1)
+            daily.forEachIndexed { index, ds ->
+                if (index % step == 0) {
+                    Text(
+                        text = ds.date.dayOfMonth.toString(),
+                        color = GrayText,
+                        fontSize = 10.sp,
+                        modifier = Modifier.weight(step.toFloat()),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TopExpenseRow(expense: TopExpense, report: FinancialReport) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(10.dp))
+            .background(PastelGreen)
+            .padding(horizontal = 14.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = expense.name.ifBlank { "Unnamed expense" },
+                color = SpendAntBlack,
+                fontWeight = FontWeight.Bold,
+                fontSize = 14.sp,
+                maxLines = 2,
+            )
+            Spacer(modifier = Modifier.height(2.dp))
+            Text(text = expense.category, color = GrayText, fontSize = 11.sp)
+        }
+        Spacer(modifier = Modifier.size(12.dp))
+        Text(
+            text = formatDisplay(expense.amountCop, report),
+            color = AmountRed,
+            fontWeight = FontWeight.Bold,
+            fontSize = 14.sp,
+        )
+    }
+}
+
+@Composable
+private fun CategoryRow(cat: CategoryTotal, total: Double, color: Color, report: FinancialReport) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = cat.label,
+                color = SpendAntBlack,
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 14.sp,
+                modifier = Modifier.weight(1f),
+            )
+            Text(
+                text = formatDisplay(cat.amountCop, report),
+                color = GrayText,
+                fontSize = 13.sp,
+            )
+        }
+        Spacer(modifier = Modifier.height(6.dp))
+        val ratio = (cat.amountCop / total).toFloat().coerceIn(0f, 1f)
+        Canvas(modifier = Modifier.fillMaxWidth().height(8.dp)) {
+            drawRect(color = Color(0xFFE0E0E0), size = size)
+            drawRect(color = color, size = Size(size.width * ratio, size.height))
+        }
+    }
+}
+
+@Composable
+private fun InsightsCard(insights: List<String>) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(10.dp))
+            .background(PastelGreen)
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Text(text = "Insights", color = SpendAntBlack, fontWeight = FontWeight.Bold, fontSize = 16.sp)
+        insights.forEach {
+            Text(text = it, color = SpendAntBlack, fontSize = 12.sp)
+        }
+    }
+}
+
+private val largeFormatter = DecimalFormat("#,##0", DecimalFormatSymbols(Locale.US))
+private val smallFormatter = DecimalFormat("#,##0.00", DecimalFormatSymbols(Locale.US))
+
+private fun formatDisplay(amountCop: Double, report: FinancialReport): String {
+    val value = amountCop * report.displayRate
+    val formatted = if (value >= 100) largeFormatter.format(value) else smallFormatter.format(value)
+    return "${report.displayCurrency} $formatted"
+}
+
+private fun openPdf(context: Context, file: File) {
+    val authority = "${context.packageName}.provider"
+    val uri = FileProvider.getUriForFile(context, authority, file)
+    val intent = Intent(Intent.ACTION_VIEW).apply {
+        setDataAndType(uri, "application/pdf")
+        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+    }
+    val chooser = Intent.createChooser(intent, "Open PDF with").apply {
+        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    }
+    context.startActivity(chooser)
+}

--- a/app/src/main/java/com/example/spendantt/viewmodel/ReportViewModel.kt
+++ b/app/src/main/java/com/example/spendantt/viewmodel/ReportViewModel.kt
@@ -1,0 +1,143 @@
+package com.example.spendantt.viewmodel
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.spendantt.data.currency.CurrencyProvider
+import com.example.spendantt.data.local.entity.ReportCacheEntity
+import com.example.spendantt.data.report.FinancialReport
+import com.example.spendantt.data.report.ReportRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import java.time.LocalDate
+import java.time.ZoneId
+
+data class ReportSetupState(
+    val startDate: LocalDate = LocalDate.now().minusDays(7),
+    val endDate: LocalDate = LocalDate.now(),
+    val firstExpenseDate: LocalDate? = null,
+    val cachedRowForCurrentRange: ReportCacheEntity? = null,
+    val recentReports: List<ReportCacheEntity> = emptyList(),
+    val isGenerating: Boolean = false,
+    val errorMessage: String? = null,
+)
+
+class ReportViewModel(
+    appContext: Context,
+    private val userId: Int,
+) : ViewModel() {
+
+    private val repo = ReportRepository(appContext.applicationContext)
+
+    private val _setup = MutableStateFlow(ReportSetupState())
+    val setup: StateFlow<ReportSetupState> = _setup.asStateFlow()
+
+    private val _currentReport = MutableStateFlow<FinancialReport?>(null)
+    val currentReport: StateFlow<FinancialReport?> = _currentReport.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            val first = repo.getFirstExpenseDate(userId)
+            val today = LocalDate.now()
+            val rawStart = first ?: today.minusDays(7)
+            val clampedStart = if (rawStart.isAfter(today)) today else rawStart
+            _setup.value = _setup.value.copy(
+                firstExpenseDate = first,
+                startDate = clampedStart,
+                endDate = today,
+            )
+            refreshCacheLookup()
+            loadRecent()
+        }
+    }
+
+    fun onStartDateChange(date: LocalDate) {
+        val today = LocalDate.now()
+        val first = _setup.value.firstExpenseDate
+        var s = date
+        if (first != null && s.isBefore(first)) s = first
+        if (s.isAfter(today)) s = today
+        val e = if (_setup.value.endDate.isBefore(s)) s else _setup.value.endDate
+        _setup.value = _setup.value.copy(startDate = s, endDate = e)
+        refreshCacheLookup()
+    }
+
+    fun onEndDateChange(date: LocalDate) {
+        val today = LocalDate.now()
+        var e = date
+        if (e.isAfter(today)) e = today
+        val s = if (_setup.value.startDate.isAfter(e)) e else _setup.value.startDate
+        _setup.value = _setup.value.copy(startDate = s, endDate = e)
+        refreshCacheLookup()
+    }
+
+    private fun refreshCacheLookup() {
+        viewModelScope.launch {
+            val s = _setup.value.startDate
+            val e = _setup.value.endDate
+            val row = repo.peekCacheRow(userId, s, e)
+            _setup.value = _setup.value.copy(cachedRowForCurrentRange = row)
+        }
+    }
+
+    private fun loadRecent() {
+        viewModelScope.launch {
+            _setup.value = _setup.value.copy(recentReports = repo.getRecentReports(userId))
+        }
+    }
+
+    /** Generate (or load from cache) and open the report. */
+    fun generate() {
+        viewModelScope.launch {
+            val s = _setup.value.startDate
+            val e = _setup.value.endDate
+            _setup.value = _setup.value.copy(isGenerating = true, errorMessage = null)
+            try {
+                val currency = CurrencyProvider.activeCurrency
+                val rate = CurrencyProvider.activeRate
+                val cached = repo.getCached(userId, s, e)
+                val report = cached ?: repo.generate(userId, s, e, currency, rate)
+                _currentReport.value = report
+                refreshCacheLookup()
+                loadRecent()
+            } catch (ex: Exception) {
+                _setup.value = _setup.value.copy(errorMessage = ex.message ?: "Failed to generate report")
+            } finally {
+                _setup.value = _setup.value.copy(isGenerating = false)
+            }
+        }
+    }
+
+    /** Open an existing cached report row directly (no aggregation). */
+    fun openCached(row: ReportCacheEntity) {
+        viewModelScope.launch {
+            val report = repo.decodeRow(row)
+            if (report != null) {
+                _setup.value = _setup.value.copy(
+                    startDate = LocalDate.ofEpochDay(row.startEpochDay),
+                    endDate = LocalDate.ofEpochDay(row.endEpochDay),
+                )
+                _currentReport.value = report
+                refreshCacheLookup()
+            }
+        }
+    }
+
+    fun closeReport() {
+        _currentReport.value = null
+    }
+
+    fun clearError() {
+        _setup.value = _setup.value.copy(errorMessage = null)
+    }
+
+    companion object {
+        fun millisToLocalDate(millis: Long): LocalDate =
+            java.time.Instant.ofEpochMilli(millis).atZone(ZoneId.systemDefault()).toLocalDate()
+
+        fun localDateToMillis(date: LocalDate): Long =
+            date.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
+    }
+}

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths>
     <cache-path name="receipts" path="." />
+    <external-files-path name="reports" path="Download/" />
+    <external-files-path name="external_files_root" path="." />
 </paths>


### PR DESCRIPTION
- New Summary flow in Profile: pick dates → report with histogram, top expenses, top categories, and insights → export PDF.

24-hour Room Cache per range (report_cache, migration 5→6) + usage counter in SharedPreferences.

- Aggregation in Dispatchers.Default; amounts in COP, conversion to active currency only upon rendering.

- Multi-page PDF (PdfDocument) with header/footer per page, name wrap to 2 lines, and category bars with reserved widths (do not overlap the amount).