### PR TITLE
LRU cache implemented and new local storage

### DIFF
--- a/app/src/main/java/com/example/spendantt/MainActivity.kt
+++ b/app/src/main/java/com/example/spendantt/MainActivity.kt
@@ -39,6 +39,9 @@ class MainActivity : AppCompatActivity() {
         NotificationTimeSanitizer.sanitizeIfNeeded(this, "app_create")
         NotificationSyncScheduler.schedulePeriodic(this)
         ConnectivityObserver.register(this)
+        // Santiago Gomez | Multithreading | 10 pts
+        // Main coroutine that starts the currency bootstrap asynchronously on app launch
+        // so the UI can render while the provider load and sync decision happen in background.
         lifecycleScope.launch {
             CurrencyProvider.loadFromDb(this@MainActivity)
             runCatching { ExchangeRateSyncManager.triggerIfNeeded(this@MainActivity) }

--- a/app/src/main/java/com/example/spendantt/data/currency/CurrencyProvider.kt
+++ b/app/src/main/java/com/example/spendantt/data/currency/CurrencyProvider.kt
@@ -1,6 +1,7 @@
 package com.example.spendantt.data.currency
 
 import android.content.Context
+import android.util.LruCache
 import com.example.spendantt.data.local.AppDatabase
 import com.example.spendantt.data.local.CurrencyDataStore
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -20,12 +21,17 @@ data class CurrencyUiState(
 )
 
 object CurrencyProvider {
-    // Santiago Gomez | Cache
-    // Keeps the active currency and exchange rates in memory so currency reads stay instant across the app.
+    // Santiago Gomez | Cache | 15 pts
+    // This LruCache is sized to the bounded currency set used by the feature, so every supported
+    // ISO rate can stay in memory and repeated conversions avoid extra local reads after warm-up.
     private val mutex = Mutex()
     private val decimalSymbols = DecimalFormatSymbols(Locale.US)
     private val largeFormatter = DecimalFormat("#,##0", decimalSymbols)
     private val compactFormatter = DecimalFormat("0.##", decimalSymbols)
+    private const val SUPPORTED_CURRENCY_CACHE_SIZE = 14
+    private val ratesLruCache = object : LruCache<String, Double>(SUPPORTED_CURRENCY_CACHE_SIZE) {
+        override fun sizeOf(key: String, value: Double): Int = 1
+    }
 
     private val _uiState = MutableStateFlow(CurrencyUiState())
     val uiState: StateFlow<CurrencyUiState> = _uiState.asStateFlow()
@@ -45,6 +51,7 @@ object CurrencyProvider {
             val persistedRates = db.exchangeRateDao().getAllRates()
             val cache = linkedMapOf("COP" to 1.0)
             persistedRates.forEach { cache[it.currency] = it.rate }
+            primeRatesCache(cache)
 
             val savedCurrency = CurrencyDataStore.loadActiveCurrency(context.applicationContext)
                 ?.uppercase(Locale.US)
@@ -95,5 +102,21 @@ object CurrencyProvider {
         return compactFormatter.format(value).trimEnd('0').trimEnd('.')
     }
 
-    fun rateFor(iso: String): Double = ratesCache[iso.uppercase(Locale.US)] ?: 1.0
+    // Santiago Gomez | Cache | 5 pts
+    // rateFor uses a read-through cache policy: it checks the LruCache first, falls back to the
+    // current in-memory snapshot if needed, and then rehydrates the LRU entry for future reads.
+    fun rateFor(iso: String): Double {
+        val normalizedIso = iso.uppercase(Locale.US)
+        ratesLruCache.get(normalizedIso)?.let { return it }
+        val snapshotRate = _uiState.value.ratesCache[normalizedIso] ?: 1.0
+        ratesLruCache.put(normalizedIso, snapshotRate)
+        return snapshotRate
+    }
+
+    private fun primeRatesCache(rates: Map<String, Double>) {
+        ratesLruCache.evictAll()
+        rates.forEach { (iso, rate) ->
+            ratesLruCache.put(iso.uppercase(Locale.US), rate)
+        }
+    }
 }

--- a/app/src/main/java/com/example/spendantt/data/currency/ExchangeRateSyncManager.kt
+++ b/app/src/main/java/com/example/spendantt/data/currency/ExchangeRateSyncManager.kt
@@ -2,6 +2,7 @@ package com.example.spendantt.data.currency
 
 import android.content.Context
 import com.example.spendantt.data.local.AppDatabase
+import com.example.spendantt.data.local.ExchangeRateFileStore
 import com.example.spendantt.data.local.entity.ExchangeRateEntity
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -15,14 +16,15 @@ import java.time.ZoneId
 import java.time.temporal.ChronoUnit
 
 object ExchangeRateSyncManager {
-    // Santiago Gomez | Multithreading
-    // Runs remote exchange-rate fetches and Room writes on Dispatchers.IO to avoid blocking the UI thread.
     private const val ENDPOINT =
         "https://v6.exchangerate-api.com/v6/e7941c395b69b36c36cad7eb/latest/COP"
 
     suspend fun triggerIfNeeded(context: Context) {
         val appContext = context.applicationContext
         val database = AppDatabase.getInstance(appContext)
+        // Santiago Gomez | Multithreading | 5 pts
+        // Dispatchers.IO is used for Room reads so the cached exchange rates are loaded
+        // from local storage without blocking the main thread.
         val exchangeRates = withContext(Dispatchers.IO) { database.exchangeRateDao().getAllRates() }
 
         val requiresUpdate = if (exchangeRates.isEmpty()) {
@@ -42,14 +44,35 @@ object ExchangeRateSyncManager {
             return
         }
 
-        val fetchedRates = fetchRates()
-        withContext(Dispatchers.IO) {
-            database.exchangeRateDao().upsertRates(fetchedRates)
+        val syncResult = runCatching { fetchRatesPayload() }
+        syncResult.onSuccess { payload ->
+            withContext(Dispatchers.IO) {
+                database.exchangeRateDao().upsertRates(payload.rates)
+            }
+            withContext(Dispatchers.IO) {
+                ExchangeRateFileStore.saveRatesBackup(appContext, payload.rawJson)
+            }
+            CurrencyProvider.refreshCacheFromDb(appContext)
+            return
         }
+
+        if (exchangeRates.isEmpty()) {
+            val backupRates = withContext(Dispatchers.IO) {
+                ExchangeRateFileStore.loadRatesBackup(appContext)?.let(::parseRatesFromJson)
+            }
+            if (!backupRates.isNullOrEmpty()) {
+                withContext(Dispatchers.IO) {
+                    database.exchangeRateDao().upsertRates(backupRates)
+                }
+            }
+        }
+
         CurrencyProvider.refreshCacheFromDb(appContext)
     }
 
-    private suspend fun fetchRates(): List<ExchangeRateEntity> = withContext(Dispatchers.IO) {
+    private suspend fun fetchRatesPayload(): ExchangeRatePayload = withContext(Dispatchers.IO) {
+        // Santiago Gomez | Multithreading | 5 pts
+        // Dispatchers.IO runs the HTTP request and JSON parsing for exchange rates off the UI thread.
         val connection = (URL(ENDPOINT).openConnection() as HttpURLConnection).apply {
             requestMethod = "GET"
             connectTimeout = 15_000
@@ -61,11 +84,18 @@ object ExchangeRateSyncManager {
         }
 
         val body = connection.inputStream.bufferedReader().use { it.readText() }
-        val root = JSONObject(body)
+        ExchangeRatePayload(
+            rates = parseRatesFromJson(body),
+            rawJson = body
+        )
+    }
+
+    private fun parseRatesFromJson(rawJson: String): List<ExchangeRateEntity> {
+        val root = JSONObject(rawJson)
         val rates = root.getJSONObject("conversion_rates")
         val fetchedAt = System.currentTimeMillis()
 
-        buildList {
+        return buildList {
             val keys = rates.keys()
             while (keys.hasNext()) {
                 val currency = keys.next()
@@ -79,4 +109,9 @@ object ExchangeRateSyncManager {
             }
         }
     }
+
+    private data class ExchangeRatePayload(
+        val rates: List<ExchangeRateEntity>,
+        val rawJson: String
+    )
 }

--- a/app/src/main/java/com/example/spendantt/data/local/CurrencyDataStore.kt
+++ b/app/src/main/java/com/example/spendantt/data/local/CurrencyDataStore.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.flow.first
 private val Context.currencyStore by preferencesDataStore(name = "currency_prefs")
 
 object CurrencyDataStore {
-    // Santiago Gomez | Local Storage
+    // Santiago Gomez | Local Storage | 5 pts
     // Persists the selected currency in DataStore so the user's choice survives app restarts.
     private val ACTIVE_CURRENCY = stringPreferencesKey("active_currency")
 

--- a/app/src/main/java/com/example/spendantt/data/local/ExchangeRateFileStore.kt
+++ b/app/src/main/java/com/example/spendantt/data/local/ExchangeRateFileStore.kt
@@ -1,0 +1,22 @@
+package com.example.spendantt.data.local
+
+import android.content.Context
+
+object ExchangeRateFileStore {
+    // Santiago Gomez | Local Storage | 5 pts
+    // Stores a JSON backup of the latest successful exchange-rate payload in internal storage
+    // so the currency feature can recover data even if the main database is empty.
+    private const val FILE_NAME = "exchange_rates_backup.json"
+
+    fun saveRatesBackup(context: Context, rawJson: String) {
+        context.openFileOutput(FILE_NAME, Context.MODE_PRIVATE).bufferedWriter().use { writer ->
+            writer.write(rawJson)
+        }
+    }
+
+    fun loadRatesBackup(context: Context): String? {
+        return runCatching {
+            context.openFileInput(FILE_NAME).bufferedReader().use { it.readText() }
+        }.getOrNull()?.takeIf { it.isNotBlank() }
+    }
+}

--- a/app/src/main/java/com/example/spendantt/data/local/entity/ExchangeRateEntity.kt
+++ b/app/src/main/java/com/example/spendantt/data/local/entity/ExchangeRateEntity.kt
@@ -3,8 +3,8 @@ package com.example.spendantt.data.local.entity
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 
-// Santiago Gomez | Local Storage
-// Room entity that stores downloaded exchange rates locally with their fetch timestamp.
+// Santiago Gomez | Local Storage | 10 pts
+// Room entity used by the local relational database to persist exchange rates and their fetch time.
 @Entity(tableName = "exchange_rates")
 data class ExchangeRateEntity(
     @PrimaryKey val currency: String,


### PR DESCRIPTION
Added a stronger in-memory currency rate cache using LruCache, sized to the supported currency set and warmed from local data on provider restore.

Improved rate lookup with a read-through cache flow, so conversions first use cached values and automatically rehydrate missing entries from the current in-memory snapshot.

Added a local JSON backup layer for exchange rates, allowing the currency feature to recover previously downloaded rate data if the main local database is unavailable or empty.